### PR TITLE
Fix syntax errors in layout and tidy imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,18 @@ from ui.sidebar_editor import render_sidebar
 from ui.bottombar import render_bottombar
 from ui.tabs_dashboard import render_dashboard
 from core.scenarios import default_scenario
-from core.calculators import piti_components, dti, debts_monthly_total, w2_row_to_monthly, schc_rows_to_monthly, k1_rows_to_monthly, c1120_rows_to_monthly, rentals_schedule_e_monthly, rentals_75pct_gross_monthly, other_income_rows_to_monthly
+from core.calculators import (
+    piti_components,
+    dti,
+    debts_monthly_total,
+    w2_row_to_monthly,
+    schc_rows_to_monthly,
+    k1_rows_to_monthly,
+    c1120_rows_to_monthly,
+    rentals_schedule_e_monthly,
+    rentals_75pct_gross_monthly,
+    other_income_rows_to_monthly,
+)
 from core.presets import DISCLAIMER
 st.set_page_config(page_title="AMALO v2", layout="wide")
 if "scenarios" not in st.session_state:

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -20,7 +20,7 @@ def render_income_column(scn):
         if cols[0].button("Edit", key=f"i_edit_{c['id']}"): st.session_state["selected"]={"kind":"income","id":c["id"]}; st.experimental_rerun()
         if cols[1].button("Duplicate", key=f"i_dup_{c['id']}"):
             import copy; scn["income_cards"].insert(i+1, copy.deepcopy(c)); st.experimental_rerun()
-        if cols[2].button("Remove", key=f"i_rm_{c['id']}"]):
+        if cols[2].button("Remove", key=f"i_rm_{c['id']}"):
             scn["income_cards"].pop(i); st.experimental_rerun()
         total+=preview
     st.caption(f"Total monthly income (preview): ${total:,.2f}")
@@ -36,7 +36,7 @@ def render_debt_column(scn):
         if cols[0].button("Edit", key=f"d_edit_{d['id']}"): st.session_state["selected"]={"kind":"debt","id":d["id"]}; st.experimental_rerun()
         if cols[1].button("Duplicate", key=f"d_dup_{d['id']}"):
             import copy; scn["debt_cards"].insert(i+1, copy.deepcopy(d)); st.experimental_rerun()
-        if cols[2].button("Remove", key=f"d_rm_{d['id']}"]):
+        if cols[2].button("Remove", key=f"d_rm_{d['id']}"):
             scn["debt_cards"].pop(i); st.experimental_rerun()
         total+=pay
     st.caption(f"Sum of listed payments (policy may adjust student loans): ${total:,.2f}")


### PR DESCRIPTION
## Summary
- Wrap calculator imports in app for readability
- Correct bracket typos causing syntax errors in layout removal buttons

## Testing
- `pytest`
- `python -m py_compile app.py`
- `python -m py_compile ui/layout.py`


------
https://chatgpt.com/codex/tasks/task_e_68a798952f8883319a23602fe5f2caf6