### PR TITLE
Rename project title to Aimlo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AMALO v2 — Mortgage Income & DTI Dashboard
+# Aimlo — Mortgage Income & DTI Dashboard
 **Built:** 2025-08-21
 
 - Thin top bar (program & targets, scenario selector)

--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ from core.calculators import (
     other_income_rows_to_monthly,
 )
 from core.presets import DISCLAIMER
-st.set_page_config(page_title="AMALO v2", layout="wide")
+st.set_page_config(page_title="Aimlo", layout="wide")
 if "scenarios" not in st.session_state:
     st.session_state["scenarios"]={"Default": default_scenario()}
     st.session_state["scenario_name"]="Default"
@@ -86,4 +86,4 @@ if st.button("Open Dashboard"):
             tmp=tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
             deal={"Scenario":st.session_state["scenario_name"],"Program":h["program"],"Rate":h["rate_pct"],"TermYears":h["term_years"],"PurchasePrice":h["purchase_price"],"BaseLoan":comp["BaseLoan"],"AdjustedLoan":comp["AdjustedLoan"],"LTV":comp["LTV"]}
             build_prequal_pdf(tmp.name, deal, summary, rules, checklist, DISCLAIMER)
-            with open(tmp.name,"rb") as f: st.download_button("Download PDF", data=f.read(), file_name=f"amalo_{st.session_state['scenario_name']}.pdf"); os.unlink(tmp.name)
+            with open(tmp.name,"rb") as f: st.download_button("Download PDF", data=f.read(), file_name=f"aimlo_{st.session_state['scenario_name']}.pdf"); os.unlink(tmp.name)

--- a/export/pdf_export.py
+++ b/export/pdf_export.py
@@ -7,7 +7,7 @@ def build_prequal_pdf(filename, deal, summary, warnings, checklist, disclaimer):
     c=canvas.Canvas(filename, pagesize=LETTER); w,h=LETTER; y=h-0.75*inch
     def line(txt, size=10, dy=14):
         nonlocal y; c.setFont('Helvetica', size); c.drawString(0.75*inch, y, txt); y-=dy
-    line('AMALO Prequalification Summary',14,18); line(datetime.now().strftime('%Y-%m-%d %H:%M'),9,14); line(' ')
+    line('Aimlo Prequalification Summary',14,18); line(datetime.now().strftime('%Y-%m-%d %H:%M'),9,14); line(' ')
     line('Deal Snapshot',12,16)
     for k in ['Scenario','Program','Rate','TermYears','PurchasePrice','BaseLoan','AdjustedLoan','LTV']: line(f"{k}: {deal.get(k,'')}")
     line(' '); line('Income & DTI',12,16)

--- a/ui/tabs_dashboard.py
+++ b/ui/tabs_dashboard.py
@@ -20,9 +20,9 @@ def render_dashboard(summary: dict, flags: dict, checklist: list, scenario_name:
     st.write('---')
     st.caption(DISCLAIMER)
     st.subheader("Exports")
-    st.download_button("Download scenario JSON", data=json.dumps({"summary":summary,"flags":flags,"checklist":checklist}, indent=2).encode("utf-8"), file_name=f"amalo_{scenario_name}.json", mime="application/json")
+    st.download_button("Download scenario JSON", data=json.dumps({"summary":summary,"flags":flags,"checklist":checklist}, indent=2).encode("utf-8"), file_name=f"aimlo_{scenario_name}.json", mime="application/json")
     csv_buf=io.StringIO(); w=csv.writer(csv_buf)
     w.writerow(["Scenario","TotalIncome","PITIA","OtherDebts","FE","BE"])
     w.writerow([scenario_name, summary.get("TotalIncome",0.0), summary.get("PITIA",0.0), summary.get("OtherDebts",0.0), summary.get("FE",0.0), summary.get("BE",0.0)])
-    st.download_button("Download CSV Summary", data=csv_buf.getvalue().encode("utf-8"), file_name=f"amalo_{scenario_name}.csv", mime="text/csv")
+    st.download_button("Download CSV Summary", data=csv_buf.getvalue().encode("utf-8"), file_name=f"aimlo_{scenario_name}.csv", mime="text/csv")
     return rules

--- a/ui/topbar.py
+++ b/ui/topbar.py
@@ -5,7 +5,7 @@ def render_topbar():
     with st.container():
         st.markdown("<div class='topbar'>", unsafe_allow_html=True)
         c1,c2,c3 = st.columns([2,5,3])
-        with c1: st.markdown("### AMALO")
+        with c1: st.markdown("### Aimlo")
         with c2:
             colA,colB,colC=st.columns(3)
             program_options=list(P.PROGRAM_PRESETS.keys())


### PR DESCRIPTION
## Summary
- Replace AMALO branding with Aimlo across README, app configuration, UI, and exports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7b60496608331ad6239f198f8917a