### PR TITLE
feat: reorganize layout with toggleable panels

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 import streamlit as st, json, tempfile, os
 from ui.topbar import render_topbar
 from ui.layout import render_income_column, render_debt_column, render_property_snapshot
-from ui.sidebar_editor import render_sidebar
 from ui.bottombar import render_bottombar
 from ui.tabs_dashboard import render_dashboard
 from core.scenarios import default_scenario
@@ -27,15 +26,24 @@ st.session_state.setdefault("sidebar_visible", True)
 st.session_state.setdefault("bottombar_visible", True)
 st.session_state.setdefault("view_mode","Data Entry")
 render_topbar()
-left, main, right = st.columns([2,5,3], gap="medium")
+if st.session_state.get("sidebar_visible", True):
+    cols = st.columns([2,5,3], gap="medium")
+    left, main, right = cols[0], cols[1], cols[2]
+else:
+    cols = st.columns([7,3], gap="medium")
+    left, main, right = None, cols[0], cols[1]
 scn = st.session_state["scenarios"][st.session_state["scenario_name"]]
-with left:
-    st.subheader("Data entry")
-    from ui.sidebar_editor import render_sidebar as _render_sidebar
-    _render_sidebar(st.session_state.get("selected"), scn, warnings=[])
+if left is not None:
+    with left:
+        st.subheader("Data entry")
+        from ui.sidebar_editor import render_sidebar as _render_sidebar
+        _render_sidebar(st.session_state.get("selected"), scn, warnings=[])
 with main:
-    render_income_column(scn)
-    render_debt_column(scn)
+    col_income, col_debt = st.columns(2)
+    with col_income:
+        render_income_column(scn)
+    with col_debt:
+        render_debt_column(scn)
 with right:
     render_property_snapshot(scn)
 # Compute totals

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -194,17 +194,26 @@ def render_property_editor(h):
     st.json({"Conventional_MI_bands":CONV_MI_BANDS,"FHA":FHA_TABLE,"VA":VA_TABLE,"USDA":USDA_TABLE})
 def render_sidebar(selected, scn, warnings):
     if selected is None or selected.get("kind") is None:
-        render_guidance_center(scn, warnings); return
-    if selected["kind"]=="income_new": render_income_new(scn); return
-    if selected["kind"]=="debt_new": render_debt_new(scn); return
-    if selected["kind"]=="income":
+        render_guidance_center(scn, warnings)
+        return
+    if selected["kind"]=="income_new":
+        render_income_new(scn)
+    elif selected["kind"]=="debt_new":
+        render_debt_new(scn)
+    elif selected["kind"]=="income":
         card=next((x for x in scn["income_cards"] if x["id"]==selected["id"]), None)
-        if not card: st.info("No card found."); return
-        render_income_editor(card); return
-    if selected["kind"]=="debt":
+        if not card:
+            st.info("No card found.")
+        else:
+            render_income_editor(card)
+    elif selected["kind"]=="debt":
         card=next((x for x in scn["debt_cards"] if x["id"]==selected["id"]), None)
-        if not card: st.info("No debt found."); return
-        policy=scn.get("settings",{}).get("student_loan_policy","Conventional")
-        render_debt_editor(card, policy); return
-    if selected["kind"]=="property":
-        render_property_editor(scn["housing"]); return
+        if not card:
+            st.info("No debt found.")
+        else:
+            policy=scn.get("settings",{}).get("student_loan_policy","Conventional")
+            render_debt_editor(card, policy)
+    elif selected["kind"]=="property":
+        render_property_editor(scn["housing"])
+    st.markdown("---")
+    render_guidance_center(scn, warnings)

--- a/ui/topbar.py
+++ b/ui/topbar.py
@@ -32,4 +32,7 @@ def render_topbar():
                 import copy; scenarios[current + " (copy)"] = copy.deepcopy(scenarios[current]); st.session_state["scenario_name"]=current + " (copy)"; st.experimental_rerun()
             if cols[3].button("🗑", help="Delete current"):
                 if len(scenarios)>1: scenarios.pop(current, None); st.session_state["scenario_name"]=list(scenarios.keys())[0]; st.experimental_rerun()
+            with st.expander("Quick Settings"):
+                st.checkbox("Show Sidebar", key="sidebar_visible", value=st.session_state.get("sidebar_visible", True))
+                st.checkbox("Show Bottom Bar", key="bottombar_visible", value=st.session_state.get("bottombar_visible", True))
         st.markdown("</div>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- allow hiding sidebar and bottom bar via new Quick Settings in top bar
- render income and debt columns side-by-side with optional sidebar column
- show guidance center beneath data entry forms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a80a874634833191b17a9b75e652b7