### PR TITLE
fix: keep sidebar titles within boxes

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,10 +48,10 @@ panel_text = colors.get("panel_text", "#ffffff")
 st.markdown(
     f"""
 <style>
-.scroll-data,.scroll-disc,.scroll-income,.scroll-debt,.scroll-prop{{max-height:400px;overflow-y:auto;border:1px solid #ccc;padding:8px;}}
-.scroll-data{{max-height:300px;}}
-.scroll-disc{{max-height:200px;}}
-.sidebar-box{{background:{panel_bg};color:{panel_text};padding:8px;}}
+.scroll-income,.scroll-debt,.scroll-prop{{max-height:400px;overflow-y:auto;border:1px solid #ccc;padding:8px;}}
+.scroll-data{{max-height:300px;overflow-y:auto;}}
+.scroll-disc{{max-height:200px;overflow-y:auto;}}
+.sidebar-box{{background:{panel_bg};color:{panel_text};padding:8px;border:1px solid #ccc;margin-bottom:8px;}}
 #sidebar_hide button,#sidebar_show button{{background:{panel_bg};color:{panel_text};border:none;}}
 #sidebar_hide,#sidebar_show{{position:absolute;top:70px;left:0;z-index:1000;}}
 #bottombar_show button{{background:{panel_bg};color:{panel_text};border:none;}}
@@ -68,6 +68,9 @@ if left is not None:
         st.markdown("<div class='scroll-data'>", unsafe_allow_html=True)
         render_sidebar(st.session_state.get("selected"), scn, warnings=[])
         st.markdown("</div>", unsafe_allow_html=True)
+        st.markdown("</div>", unsafe_allow_html=True)
+
+        st.markdown("<div class='sidebar-box'>", unsafe_allow_html=True)
         st.subheader("Disclosures")
         st.markdown("<div class='scroll-disc'>", unsafe_allow_html=True)
         render_guidance_center(scn, warnings=[])

--- a/core/version.py
+++ b/core/version.py
@@ -1,4 +1,4 @@
 """Project version information."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,4 +12,5 @@ All notable changes to this project will be documented in this file.
 - Scrollable container layout with bottom bar document checklist.
 
 - Sidebar and bottom bar toggle arrows with dark gray styling.
+- Sidebar headers now appear inside their bordered boxes for clearer grouping.
 


### PR DESCRIPTION
## Summary
- place Data entry and Disclosures headers inside bordered sidebar cards
- document UI fix and bump version to 0.3.1

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a815d49e988331a89841874a9c8c38