### PR TITLE
fix: replace experimental rerun

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,13 +33,13 @@ render_topbar()
 if st.session_state.get("sidebar_visible", True):
     if st.button("\u25c0", key="sidebar_hide"):
         hide_sidebar()
-        st.experimental_rerun()
+        st.rerun()
     cols = st.columns([2,5,3], gap="medium")
     left, main, right = cols[0], cols[1], cols[2]
 else:
     if st.button("\u25b6", key="sidebar_show"):
         show_sidebar()
-        st.experimental_rerun()
+        st.rerun()
     cols = st.columns([7,3], gap="medium")
     left, main, right = None, cols[0], cols[1]
 colors = THEME["colors"]
@@ -112,8 +112,8 @@ checklist=document_checklist(scn["income_cards"])
 render_bottombar(st.session_state["bottombar_visible"], summary, checklist)
 if not st.session_state["bottombar_visible"]:
     if st.button("\u25b2", key="bottombar_show"):
-        show_bottombar()
-        st.experimental_rerun()
+          show_bottombar()
+          st.rerun()
 st.write("---")
 if st.button("Open Dashboard"):
     flags={"k1_gate_ok": all((p.get("payload",{}).get("verified_distributions") or p.get("payload",{}).get("analyzed_liquidity")) for p in scn["income_cards"] if p.get("type")=="K-1") if any(p.get("type")=="K-1" for p in scn["income_cards"]) else True,

--- a/core/version.py
+++ b/core/version.py
@@ -1,4 +1,4 @@
 """Project version information."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,12 +5,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Initial project scaffolding and mandatory metadata files.
 
- 
 ### Fixed
 - Install pytest in CI workflow to enable test execution.
-
 - Scrollable container layout with bottom bar document checklist.
-
 - Sidebar and bottom bar toggle arrows with dark gray styling.
 - Sidebar headers now appear inside their bordered boxes for clearer grouping.
+- Replace deprecated `st.experimental_rerun` calls with `st.rerun` for Streamlit 1.27+ compatibility.
 

--- a/ui/bottombar.py
+++ b/ui/bottombar.py
@@ -8,7 +8,7 @@ def render_bottombar(enabled, summary, checklist):
     if st.button("▼", key="bottombar_hide"):
         from ui.utils import hide_bottombar
         hide_bottombar()
-        st.experimental_rerun()
+        st.rerun()
     fe, be = summary.get("FE", 0.0), summary.get("BE", 0.0)
     fe_t, be_t = summary.get("FE_target", 1.0), summary.get("BE_target", 1.0)
     fe_ok = fe <= fe_t

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -2,7 +2,7 @@ import streamlit as st
 from core.calculators import w2_row_to_monthly, schc_rows_to_monthly, k1_rows_to_monthly, c1120_rows_to_monthly, rentals_schedule_e_monthly, rentals_75pct_gross_monthly, other_income_rows_to_monthly
 def render_income_column(scn):
     st.subheader("All Income")
-    if st.button("Add income card"): st.session_state["selected"]={"kind":"income_new","id":None}; st.experimental_rerun()
+    if st.button("Add income card"): st.session_state["selected"]={"kind":"income_new","id":None}; st.rerun()
     total=0.0
     for i,c in enumerate(scn["income_cards"]):
         preview=0.0; t=c.get("type"); p=c.get("payload",{})
@@ -17,31 +17,31 @@ def render_income_column(scn):
         title=p.get("employer") or p.get("business_name") or p.get("entity_name") or p.get("corp_name") or p.get("property") or p.get("type") or t
         st.write(f"**{t}** — {title or ''} • ${preview:,.2f}/mo")
         cols=st.columns(3)
-        if cols[0].button("Edit", key=f"i_edit_{c['id']}"): st.session_state["selected"]={"kind":"income","id":c["id"]}; st.experimental_rerun()
+        if cols[0].button("Edit", key=f"i_edit_{c['id']}"): st.session_state["selected"]={"kind":"income","id":c["id"]}; st.rerun()
         if cols[1].button("Duplicate", key=f"i_dup_{c['id']}"):
-            import copy; scn["income_cards"].insert(i+1, copy.deepcopy(c)); st.experimental_rerun()
+            import copy; scn["income_cards"].insert(i+1, copy.deepcopy(c)); st.rerun()
         if cols[2].button("Remove", key=f"i_rm_{c['id']}"):
-            scn["income_cards"].pop(i); st.experimental_rerun()
+            scn["income_cards"].pop(i); st.rerun()
         total+=preview
     st.caption(f"Total monthly income (preview): ${total:,.2f}")
 def render_debt_column(scn):
     st.subheader("All Debts/Liabilities")
-    if st.button("Add debt card"): st.session_state["selected"]={"kind":"debt_new","id":None}; st.experimental_rerun()
+    if st.button("Add debt card"): st.session_state["selected"]={"kind":"debt_new","id":None}; st.rerun()
     total=0.0
     for i,d in enumerate(scn["debt_cards"]):
         title = (d.get("type","") + (" • " + d.get("name","") if d.get("name") else ""))
         pay = float(d.get("monthly_payment",0.0))
         st.write(f"**{title}** — ${pay:,.2f}/mo")
         cols=st.columns(3)
-        if cols[0].button("Edit", key=f"d_edit_{d['id']}"): st.session_state["selected"]={"kind":"debt","id":d["id"]}; st.experimental_rerun()
+        if cols[0].button("Edit", key=f"d_edit_{d['id']}"): st.session_state["selected"]={"kind":"debt","id":d["id"]}; st.rerun()
         if cols[1].button("Duplicate", key=f"d_dup_{d['id']}"):
-            import copy; scn["debt_cards"].insert(i+1, copy.deepcopy(d)); st.experimental_rerun()
+            import copy; scn["debt_cards"].insert(i+1, copy.deepcopy(d)); st.rerun()
         if cols[2].button("Remove", key=f"d_rm_{d['id']}"):
-            scn["debt_cards"].pop(i); st.experimental_rerun()
+            scn["debt_cards"].pop(i); st.rerun()
         total+=pay
     st.caption(f"Sum of listed payments (policy may adjust student loans): ${total:,.2f}")
 def render_property_snapshot(scn):
     st.subheader("Property Info")
     h=scn["housing"]
     st.write(f"Price ${h.get('purchase_price',0):,.0f} | DP ${h.get('down_payment_amt',0):,.0f} | Rate {h.get('rate_pct',0):.3f}% | Term {h.get('term_years',0)}y")
-    if st.button("Edit property & program (open sidebar)", key="prop_edit"): st.session_state["selected"]={"kind":"property","id":"housing"}; st.experimental_rerun()
+    if st.button("Edit property & program (open sidebar)", key="prop_edit"): st.session_state["selected"]={"kind":"property","id":"housing"}; st.rerun()

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -59,13 +59,13 @@ def render_income_new(scn):
           "Other":{"borrower_id":1,"type":"Social Security","gross_monthly":0.0,"gross_up_pct":0.0,"continuance_3yr":False},
         }
         scn["income_cards"].append({"id":cid,"type":typ,"payload":defaults[typ]})
-        st.session_state["selected"]={"kind":"income","id":cid}; st.experimental_rerun()
+        st.session_state["selected"]={"kind":"income","id":cid}; st.rerun()
 def render_debt_new(scn):
     typ = st.selectbox("Debt type", ["installment","revolving","student_loan","support"], key="new_debt_typ")
     if st.button("Create debt card"):
         cid=_id()
         scn["debt_cards"].append({"id":cid,"borrower_id":1,"type":typ,"name":"","monthly_payment":0.0,"remaining_payments":None,"exclude_lt_10":False,"pay_off_at_close":False,"sl_balance":0.0,"sl_documented_payment":0.0,"sl_amortizing":False})
-        st.session_state["selected"]={"kind":"debt","id":cid}; st.experimental_rerun()
+        st.session_state["selected"]={"kind":"debt","id":cid}; st.rerun()
 def render_income_editor(card):
     t=card["type"]; p=card["payload"]
     st.number_input("Borrower ID (1-6)", value=int(p.get("borrower_id",1)), min_value=1, max_value=6, step=1, key=f"ed_bid_{card['id']}")

--- a/ui/topbar.py
+++ b/ui/topbar.py
@@ -25,11 +25,11 @@ def render_topbar():
             cols = st.columns([3,1,1,1])
             choose = cols[0].selectbox("Scenario", names, index=idx, key="scenario_select")
             if choose != current:
-                st.session_state["scenario_name"]=choose; st.experimental_rerun()
+                st.session_state["scenario_name"]=choose; st.rerun()
             if cols[1].button("＋", help="New scenario"):
-                base=names[0]; scenarios[f"Scenario {len(names)+1}"] = {**scenarios[base]}; st.session_state["scenario_name"]=f"Scenario {len(names)+1}"; st.experimental_rerun()
+                base=names[0]; scenarios[f"Scenario {len(names)+1}"] = {**scenarios[base]}; st.session_state["scenario_name"]=f"Scenario {len(names)+1}"; st.rerun()
             if cols[2].button("⧉", help="Duplicate current"):
-                import copy; scenarios[current + " (copy)"] = copy.deepcopy(scenarios[current]); st.session_state["scenario_name"]=current + " (copy)"; st.experimental_rerun()
+                import copy; scenarios[current + " (copy)"] = copy.deepcopy(scenarios[current]); st.session_state["scenario_name"]=current + " (copy)"; st.rerun()
             if cols[3].button("🗑", help="Delete current"):
-                if len(scenarios)>1: scenarios.pop(current, None); st.session_state["scenario_name"]=list(scenarios.keys())[0]; st.experimental_rerun()
+                if len(scenarios)>1: scenarios.pop(current, None); st.session_state["scenario_name"]=list(scenarios.keys())[0]; st.rerun()
         st.markdown("</div>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- replace deprecated `st.experimental_rerun` with `st.rerun` across app and UI components
- bump version to 0.3.2

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a89767a2d48331bd0764a90513c930