### PR TITLE
feat: borrower names on top bar with dropdown selection

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,4 +1,4 @@
 """Project version information."""
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Initial project scaffolding and mandatory metadata files.
+- Borrower names editable from top bar with dropdown selection on entry cards.
 
 ### Fixed
 - Install pytest in CI workflow to enable test execution.

--- a/tests/unit/test_borrower_dropdown.py
+++ b/tests/unit/test_borrower_dropdown.py
@@ -1,0 +1,18 @@
+import streamlit as st
+from core.scenarios import default_scenario
+from ui.utils import borrower_selectbox
+
+
+def test_borrower_selectbox(monkeypatch):
+    st.session_state.clear()
+    scn = default_scenario()
+    st.session_state["scenarios"] = {"Default": scn}
+    st.session_state["scenario_name"] = "Default"
+
+    def fake_selectbox(label, options, index=0, key=None):
+        assert label == "Borrower"
+        return options[1]
+
+    monkeypatch.setattr(st, "selectbox", fake_selectbox)
+    selected_id = borrower_selectbox("Borrower", 1, key="test")
+    assert selected_id == 2

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -3,6 +3,7 @@ from core.calculators import (
     w2_row_to_monthly, schc_rows_to_monthly, k1_rows_to_monthly, c1120_rows_to_monthly,
     rentals_schedule_e_monthly, rentals_75pct_gross_monthly, other_income_rows_to_monthly
 )
+from ui.utils import borrower_selectbox
 from core.presets import CONV_MI_BANDS, FHA_TABLE, VA_TABLE, USDA_TABLE, DISCLAIMER
 
 HELP_MAP={
@@ -68,7 +69,7 @@ def render_debt_new(scn):
         st.session_state["selected"]={"kind":"debt","id":cid}; st.rerun()
 def render_income_editor(card):
     t=card["type"]; p=card["payload"]
-    st.number_input("Borrower ID (1-6)", value=int(p.get("borrower_id",1)), min_value=1, max_value=6, step=1, key=f"ed_bid_{card['id']}")
+    p["borrower_id"] = borrower_selectbox("Borrower", int(p.get("borrower_id",1)), key=f"ed_bid_{card['id']}")
     if t=="W-2":
         p["employer"]=st.text_input("Employer", value=p.get("employer",""))
         pt=st.radio("Pay Type", ["Salary","Hourly"], index=0 if p.get("pay_type","Salary")=="Salary" else 1, horizontal=True); p["pay_type"]=pt
@@ -178,6 +179,7 @@ def render_income_editor(card):
         st.caption(f"Monthly preview: ${other_income_rows_to_monthly([p]):,.2f}")
 def render_debt_editor(card, policy):
     d=card
+    d["borrower_id"] = borrower_selectbox("Borrower", int(d.get("borrower_id",1)), key=f"deb_bid_{d['id']}")
     d["type"]=st.selectbox("Type", ["installment","revolving","student_loan","support"], index=["installment","revolving","student_loan","support"].index(d.get("type","installment")))
     d["name"]=st.text_input("Name/Description", value=d.get("name",""))
     c1,c2=st.columns(2)

--- a/ui/topbar.py
+++ b/ui/topbar.py
@@ -1,12 +1,20 @@
 import streamlit as st
 from core import presets as P
+from core.version import __version__
 def render_topbar():
     st.markdown("""<style>.topbar{position:sticky;top:0;z-index:999;background:var(--background-color);padding:6px 6px;border-bottom:1px solid #eee}</style>""", unsafe_allow_html=True)
     with st.container():
         st.markdown("<div class='topbar'>", unsafe_allow_html=True)
-        c1,c2,c3 = st.columns([2,5,3])
-        with c1: st.markdown("### Aimlo")
+        c1,c2,c3,c4 = st.columns([2,3,5,3])
+        with c1:
+            st.markdown(f"### Aimlo — v{__version__}")
         with c2:
+            scn = st.session_state["scenarios"][st.session_state["scenario_name"]]
+            for bid in sorted(scn.get("borrowers", {})):
+                scn["borrowers"][bid] = st.text_input(
+                    f"Borrower {bid}", value=scn["borrowers"].get(bid, f"Borrower {bid}"), key=f"tb_br_{bid}"
+                )
+        with c3:
             colA,colB,colC=st.columns(3)
             program_options=list(P.PROGRAM_PRESETS.keys())
             default_program=st.session_state.get("program", program_options[0])
@@ -18,7 +26,7 @@ def render_topbar():
             st.session_state.setdefault("fe_target", fe_default); st.session_state.setdefault("be_target", be_default)
             st.session_state["fe_target"]=colB.number_input("FE Target", value=float(st.session_state["fe_target"]), min_value=0.0, max_value=1.0, step=0.01)
             st.session_state["be_target"]=colC.number_input("BE Target", value=float(st.session_state["be_target"]), min_value=0.0, max_value=1.0, step=0.01)
-        with c3:
+        with c4:
             scenarios = st.session_state["scenarios"]; names = list(scenarios.keys())
             current = st.session_state.get("scenario_name", names[0])
             idx = names.index(current) if current in names else 0

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -12,3 +12,13 @@ def show_bottombar():
 
 def hide_bottombar():
     st.session_state["bottombar_visible"] = False
+
+
+def borrower_selectbox(label: str, current_id: int, key: str) -> int:
+    """Render a selectbox of borrower names and return selected borrower ID."""
+    scn = st.session_state["scenarios"][st.session_state["scenario_name"]]
+    borrowers = scn.get("borrowers", {})
+    names = [borrowers[b] for b in sorted(borrowers)]
+    current_name = borrowers.get(current_id, names[0] if names else "")
+    chosen = st.selectbox(label, names, index=names.index(current_name), key=key)
+    return next((bid for bid, nm in borrowers.items() if nm == chosen), current_id)


### PR DESCRIPTION
## Summary
- allow editing borrower names in the top bar and display app version
- use borrower name dropdowns on income and debt entry cards
- add helper utility and accompanying unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a899e619688331b7ad308d411d89fd