### PR TITLE
feat: add fixed sidebar layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from ui.tabs_dashboard import render_dashboard
 from ui.sidebar_editor import render_sidebar, render_guidance_center
 from ui.utils import show_sidebar, hide_sidebar, show_bottombar
 from ui.theme import THEME
+from ui.layout_helpers import build_sidebar_css, SIDEBAR_WIDTH
 from core.scenarios import default_scenario
 from core.calculators import (
     piti_components,
@@ -29,54 +30,42 @@ st.session_state.setdefault("selected", {"kind":None,"id":None})
 st.session_state.setdefault("sidebar_visible", True)
 st.session_state.setdefault("bottombar_visible", True)
 st.session_state.setdefault("view_mode","Data Entry")
+# Render top bar and compute style variables
 render_topbar()
-if st.session_state.get("sidebar_visible", True):
-    if st.button("\u25c0", key="sidebar_hide"):
-        hide_sidebar()
-        st.rerun()
-    cols = st.columns([2,5,3], gap="medium")
-    left, main, right = cols[0], cols[1], cols[2]
-else:
-    if st.button("\u25b6", key="sidebar_show"):
-        show_sidebar()
-        st.rerun()
-    cols = st.columns([7,3], gap="medium")
-    left, main, right = None, cols[0], cols[1]
 colors = THEME["colors"]
 panel_bg = colors.get("panel_bg", "#333333")
 panel_text = colors.get("panel_text", "#ffffff")
+sidebar_visible = st.session_state.get("sidebar_visible", True)
 st.markdown(
-    f"""
-<style>
-.scroll-income,.scroll-debt,.scroll-prop{{max-height:400px;overflow-y:auto;border:1px solid #ccc;padding:8px;}}
-.scroll-data{{max-height:300px;overflow-y:auto;}}
-.scroll-disc{{max-height:200px;overflow-y:auto;}}
-.sidebar-box{{background:{panel_bg};color:{panel_text};padding:8px;border:1px solid #ccc;margin-bottom:8px;}}
-#sidebar_hide button,#sidebar_show button{{background:{panel_bg};color:{panel_text};border:none;}}
-#sidebar_hide,#sidebar_show{{position:absolute;top:70px;left:0;z-index:1000;}}
-#bottombar_show button{{background:{panel_bg};color:{panel_text};border:none;}}
-#bottombar_show{{position:fixed;bottom:0;right:10px;z-index:1000;}}
-</style>
-""",
+    build_sidebar_css(panel_bg, panel_text, sidebar_visible, SIDEBAR_WIDTH),
     unsafe_allow_html=True,
 )
-scn = st.session_state["scenarios"][st.session_state["scenario_name"]]
-if left is not None:
-    with left:
-        st.markdown("<div class='sidebar-box'>", unsafe_allow_html=True)
-        st.subheader("Data entry")
-        st.markdown("<div class='scroll-data'>", unsafe_allow_html=True)
-        render_sidebar(st.session_state.get("selected"), scn, warnings=[])
-        st.markdown("</div>", unsafe_allow_html=True)
-        st.markdown("</div>", unsafe_allow_html=True)
 
-        st.markdown("<div class='sidebar-box'>", unsafe_allow_html=True)
-        st.subheader("Disclosures")
-        st.markdown("<div class='scroll-disc'>", unsafe_allow_html=True)
-        render_guidance_center(scn, warnings=[])
-        st.markdown("</div>", unsafe_allow_html=True)
-        st.markdown("</div>", unsafe_allow_html=True)
-with main:
+# Toggle button to show/hide sidebar
+st.markdown("<div class='sidebar-toggle'>", unsafe_allow_html=True)
+if sidebar_visible:
+    if st.button("\u25c0", key="sidebar_hide"):
+        hide_sidebar(); st.rerun()
+else:
+    if st.button("\u25b6", key="sidebar_show"):
+        show_sidebar(); st.rerun()
+st.markdown("</div>", unsafe_allow_html=True)
+
+scn = st.session_state["scenarios"][st.session_state["scenario_name"]]
+if sidebar_visible:
+    st.markdown("<div class='fixed-sidebar'>", unsafe_allow_html=True)
+    st.markdown("<div class='data'>", unsafe_allow_html=True)
+    st.subheader("Data entry")
+    render_sidebar(st.session_state.get("selected"), scn, warnings=[])
+    st.markdown("</div>", unsafe_allow_html=True)
+    st.markdown("<div class='disc'>", unsafe_allow_html=True)
+    st.subheader("Disclosures")
+    render_guidance_center(scn, warnings=[])
+    st.markdown("</div>", unsafe_allow_html=True)
+    st.markdown("</div>", unsafe_allow_html=True)
+
+col_main, right = st.columns([5,3], gap="medium")
+with col_main:
     col_income, col_debt = st.columns(2)
     with col_income:
         st.markdown("<div class='scroll-income'>", unsafe_allow_html=True)

--- a/core/version.py
+++ b/core/version.py
@@ -1,4 +1,4 @@
 """Project version information."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.1"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,4 +12,8 @@ All notable changes to this project will be documented in this file.
 - Sidebar and bottom bar toggle arrows with dark gray styling.
 - Sidebar headers now appear inside their bordered boxes for clearer grouping.
 - Replace deprecated `st.experimental_rerun` calls with `st.rerun` for Streamlit 1.27+ compatibility.
+- Fixed sidebar no longer obscures main content and its sections scroll within bounds.
+
+### Changed
+- Sidebar redesigned as fixed-width full-height panel with bottom disclosures box.
 

--- a/tests/integration/test_guidance_center.py
+++ b/tests/integration/test_guidance_center.py
@@ -1,0 +1,9 @@
+import streamlit as st
+from ui.sidebar_editor import render_guidance_center
+
+def test_guidance_center_disclosures(monkeypatch):
+    outputs = []
+    monkeypatch.setattr(st, 'segmented_control', lambda label, opts, key=None: 'Disclosures')
+    monkeypatch.setattr(st, 'caption', lambda msg: outputs.append(msg))
+    render_guidance_center({}, warnings=[])
+    assert outputs, 'disclosure text should be rendered'

--- a/tests/unit/test_layout_helpers.py
+++ b/tests/unit/test_layout_helpers.py
@@ -1,0 +1,8 @@
+from ui.layout_helpers import build_sidebar_css, SIDEBAR_WIDTH
+
+def test_build_sidebar_css_width_and_visibility():
+    css_visible = build_sidebar_css('#000', '#fff', True, SIDEBAR_WIDTH)
+    assert f"width:{SIDEBAR_WIDTH}px" in css_visible
+    assert f"margin-left:{SIDEBAR_WIDTH}px" in css_visible
+    css_hidden = build_sidebar_css('#000', '#fff', False, SIDEBAR_WIDTH)
+    assert 'display:none' in css_hidden

--- a/ui/layout_helpers.py
+++ b/ui/layout_helpers.py
@@ -1,0 +1,42 @@
+"""Helper functions for layout styling."""
+from __future__ import annotations
+
+SIDEBAR_WIDTH = 260
+
+
+def build_sidebar_css(panel_bg: str, panel_text: str, visible: bool, width: int = SIDEBAR_WIDTH) -> str:
+    """Return CSS for the fixed sidebar and main area.
+
+    Parameters
+    ----------
+    panel_bg: str
+        Background color for sidebar panels.
+    panel_text: str
+        Text color for sidebar panels.
+    visible: bool
+        Whether the sidebar should be visible.
+    width: int
+        Fixed width of the sidebar in pixels.
+    """
+    base = f"""
+<style>
+.fixed-sidebar{{position:fixed;top:60px;bottom:0;left:0;width:{width}px;background:{panel_bg};color:{panel_text};display:flex;flex-direction:column;border-right:1px solid #ccc;z-index:100;}}
+.fixed-sidebar .data{{flex:1;overflow-y:auto;padding:8px;}}
+.fixed-sidebar .disc{{border-top:1px solid #ccc;padding:8px;max-height:180px;overflow-y:auto;}}
+.block-container{{margin-left:{width}px;padding-left:16px;padding-right:16px;}}
+.sidebar-toggle{{position:fixed;top:70px;left:{width}px;z-index:1000;}}
+.sidebar-toggle button{{background:{panel_bg};color:{panel_text};border:none;}}
+.scroll-income,.scroll-debt,.scroll-prop{{max-height:400px;overflow-y:auto;border:1px solid #ccc;padding:8px;}}
+#bottombar_show button{{background:{panel_bg};color:{panel_text};border:none;}}
+#bottombar_show{{position:fixed;bottom:0;right:10px;z-index:1000;}}
+</style>
+"""
+    if not visible:
+        base += f"""
+<style>
+.fixed-sidebar{{display:none;}}
+.block-container{{margin-left:0;}}
+.sidebar-toggle{{left:0;}}
+</style>
+"""
+    return base


### PR DESCRIPTION
## Summary
- redesign sidebar as fixed-width full-height panel with bottom disclosures box
- ensure main content remains visible by shifting block container and confining sidebar scrolling
- document layout fix and bump version to 0.6.1

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8a3ec9d788331b93c3a9e3e651c21