### PR TITLE
feat: simplify layout with overlay drawers

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,6 @@ from core.calculators import (
     rentals_75pct_gross_monthly,
     other_income_rows_to_monthly,
 )
-from core.checklist import document_checklist
 
 st.set_page_config(page_title="Aimlo", layout="wide")
 if "scenarios" not in st.session_state:
@@ -25,7 +24,7 @@ if "scenarios" not in st.session_state:
     st.session_state["scenario_name"] = "Default"
 st.session_state.setdefault("drawer_open", False)
 st.session_state.setdefault("active_editor", None)
-st.session_state.setdefault("bottombar_visible", True)
+st.session_state.setdefault("bottombar_visible", False)
 
 render_topbar()
 scn = st.session_state["scenarios"][st.session_state["scenario_name"]]
@@ -77,8 +76,7 @@ summary = {
     "FE_target": st.session_state.get("fe_target", 0.31),
     "BE_target": st.session_state.get("be_target", 0.43),
 }
-checklist = document_checklist(scn.get("income_cards", []))
-render_bottombar(st.session_state["bottombar_visible"], summary, checklist)
+render_bottombar(st.session_state["bottombar_visible"], summary)
 if not st.session_state["bottombar_visible"]:
     if st.button("\u25b2", key="bottombar_show"):
         show_bottombar()

--- a/core/version.py
+++ b/core/version.py
@@ -1,4 +1,4 @@
 """Project version information."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
-- Drawer sidebar and three-column layout.
+- Compact bottom summary drawer with snapshot totals.
 - Initial project scaffolding and mandatory metadata files.
 - Borrower sidebar cards for name, contact, and credit info with top bar dropdown selection.
 
@@ -16,6 +16,6 @@ All notable changes to this project will be documented in this file.
 - Missing income cards and overflowing disclosure box by restructuring layout with Streamlit columns.
 
 ### Changed
-- Main view uses new wireframe with drawer.
-- Sidebar redesigned as fixed-width full-height panel with bottom disclosures box.
+- Removed left data-entry column; main grid shows income, debts, and property boxes only.
+- All data entry forms open in an overlay drawer with disclosures and guides.
 

--- a/tests/integration/test_drawers_smoke.py
+++ b/tests/integration/test_drawers_smoke.py
@@ -1,0 +1,16 @@
+import streamlit as st
+from ui.utils import show_sidebar, hide_sidebar, show_bottombar, hide_bottombar
+
+
+def test_drawers_smoke():
+    st.session_state.clear()
+    assert st.session_state.get("drawer_open", False) is False
+    assert st.session_state.get("bottombar_visible", False) is False
+    show_sidebar()
+    show_bottombar()
+    assert st.session_state["drawer_open"] is True
+    assert st.session_state["bottombar_visible"] is True
+    hide_sidebar()
+    hide_bottombar()
+    assert st.session_state["drawer_open"] is False
+    assert st.session_state["bottombar_visible"] is False

--- a/tests/integration/test_guidance_center.py
+++ b/tests/integration/test_guidance_center.py
@@ -1,9 +1,17 @@
 import streamlit as st
-from ui.sidebar_editor import render_guidance_center
+from ui.disclosures import render_disclosures
 
-def test_guidance_center_disclosures(monkeypatch):
+
+def test_disclosures_tab(monkeypatch):
     outputs = []
-    monkeypatch.setattr(st, 'segmented_control', lambda label, opts, key=None: 'Disclosures')
+    def fake_tabs(options):
+        class Dummy:
+            def __enter__(self):
+                return None
+            def __exit__(self, exc_type, exc, tb):
+                return False
+        return Dummy(), Dummy(), Dummy(), Dummy()
+    monkeypatch.setattr(st, 'tabs', lambda opts: fake_tabs(opts))
     monkeypatch.setattr(st, 'caption', lambda msg: outputs.append(msg))
-    render_guidance_center({}, warnings=[])
+    render_disclosures([])
     assert outputs, 'disclosure text should be rendered'

--- a/ui/bottombar.py
+++ b/ui/bottombar.py
@@ -2,39 +2,48 @@ import streamlit as st
 from ui.theme import THEME
 
 
-def render_bottombar(enabled, summary, checklist):
-    if not enabled:
-        return
-    if st.button("▼", key="bottombar_hide"):
-        from ui.utils import hide_bottombar
-        hide_bottombar()
-        st.rerun()
+def render_bottombar(open_state, summary):
+    colors = THEME["colors"]
+    bg = colors.get("panel_bg", "#333")
+    text = colors.get("panel_text", "#fff")
+    border = colors.get("border", "#eee")
+    transition = THEME["drawer"]["transition_ms"]
+
     fe, be = summary.get("FE", 0.0), summary.get("BE", 0.0)
     fe_t, be_t = summary.get("FE_target", 1.0), summary.get("BE_target", 1.0)
     fe_ok = fe <= fe_t
     be_ok = be <= be_t
-    docs_html = "".join(
-        f"<div><input type='checkbox'> {item}</div>" for item in checklist
-    )
-    colors = THEME["colors"]
-    bg = colors.get("panel_bg", "#333333")
-    text = colors.get("panel_text", "#ffffff")
+
     st.markdown(
         f"""
     <style>
-    .bb{{position:fixed;bottom:0;left:0;right:0;background:{bg};color:{text};border-top:1px solid #eee;padding:8px;z-index:998}}
-    .bb span{{margin-right:16px}}
-    .doclist{{position:fixed;bottom:40px;right:0;background:{bg};color:{text};border:1px solid #eee;padding:8px;max-height:200px;overflow-y:auto;z-index:999}}
+    .bottomdrawer{{position:fixed;left:0;right:0;bottom:0;background:{bg};color:{text};border-top:1px solid {border};padding:8px;transform:translateY(100%);transition:transform {transition}ms;z-index:998}}
+    .bottomdrawer.open{{transform:translateY(0);}}
+    .bottomdrawer span{{margin-right:16px}}
     </style>
-    <div class='bb'><span><b>Income</b> ${summary.get('TotalIncome',0):,.2f}</span>
-    <span><b>PITIA</b> ${summary.get('PITIA',0):,.2f}</span>
-    <span><b>FE</b> {fe:.2%} ({'PASS' if fe_ok else 'CHECK'})</span>
-    <span><b>BE</b> {be:.2%} ({'PASS' if be_ok else 'CHECK'})</span></div>
-    <div class='doclist'>{docs_html}</div>
     """,
         unsafe_allow_html=True,
     )
+
+    classes = "bottomdrawer open" if open_state else "bottomdrawer"
     st.markdown(
-        "<style>#bottombar_hide{position:fixed;bottom:40px;right:10px;z-index:1000}</style>",
+        f"""
+    <div class='{classes}'>
+        <span><b>Income</b> ${summary.get('TotalIncome',0):,.2f}</span>
+        <span><b>PITIA</b> ${summary.get('PITIA',0):,.2f}</span>
+        <span><b>FE</b> {fe:.2%} ({'PASS' if fe_ok else 'CHECK'})</span>
+        <span><b>BE</b> {be:.2%} ({'PASS' if be_ok else 'CHECK'})</span>
+    </div>
+    """,
         unsafe_allow_html=True,
     )
+
+    if open_state:
+        if st.button("▼", key="bottombar_hide"):
+            from ui.utils import hide_bottombar
+            hide_bottombar()
+            st.rerun()
+        st.markdown(
+            "<style>#bottombar_hide{position:fixed;bottom:40px;right:10px;z-index:1000}</style>",
+            unsafe_allow_html=True,
+        )

--- a/ui/disclosures.py
+++ b/ui/disclosures.py
@@ -2,6 +2,7 @@
 import streamlit as st
 import yaml
 from pathlib import Path
+from core.presets import DISCLAIMER
 
 _HINTS_CACHE = None
 
@@ -14,7 +15,14 @@ def _load_hints():
 
 def render_disclosures(warnings):
     hints = _load_hints()
-    guides_tab, warn_tab, where_tab = st.tabs(["Guides", "Warnings", "Where to find"])
+    disc_tab, guides_tab, warn_tab, where_tab = st.tabs([
+        "Disclosures",
+        "Guides",
+        "Warnings",
+        "Where to find",
+    ])
+    with disc_tab:
+        st.caption(DISCLAIMER)
     with guides_tab:
         if not hints:
             st.info("No guides available.")

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -2,18 +2,14 @@ import streamlit as st
 from ui.cards_income import render_income_board
 from ui.cards_debts import render_debt_board
 from ui.panel_property import render_property_panel
-from ui.disclosures import render_disclosures
 
 
 def render_layout(scn):
-    col_a, col_b, col_c = st.columns([1, 1, 1])
-    with col_a:
-        st.subheader("Data entry")
-        st.info("Select an item to edit from the main panel.")
-        st.subheader("Disclosures")
-        render_disclosures(warnings=[])
-    with col_b:
+    """Main three-column layout with income, debts, and property boxes."""
+    col_income, col_debts, col_prop = st.columns([1, 1, 1])
+    with col_income:
         render_income_board(scn)
-    with col_c:
+    with col_debts:
         render_debt_board(scn)
+    with col_prop:
         render_property_panel(scn)


### PR DESCRIPTION
## Summary
- remove data-entry sidebar and show only income, debt, and property boxes
- add dark overlay drawer for all forms and disclosures
- introduce compact bottom summary drawer with DTI snapshot

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b7807f408331b2da633cc8d9826f