### PR TITLE
fix: handle string targets in bottom bar

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,4 +1,4 @@
 """Project version information."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Sidebar headers now appear inside their bordered boxes for clearer grouping.
 - Replace deprecated `st.experimental_rerun` calls with `st.rerun` for Streamlit 1.27+ compatibility.
 - Missing income cards and overflowing disclosure box by restructuring layout with Streamlit columns.
+- Prevent type errors in bottom bar when FE/BE targets are provided as strings.
 
 ### Changed
 - Removed left data-entry column; main grid shows income, debts, and property boxes only.

--- a/tests/unit/test_bottombar.py
+++ b/tests/unit/test_bottombar.py
@@ -1,0 +1,8 @@
+import streamlit as st
+from ui.bottombar import render_bottombar
+
+
+def test_render_bottombar_handles_string_targets():
+    st.session_state.clear()
+    summary = {"FE": 0.1, "BE": 0.2, "FE_target": "0.31", "BE_target": "0.43"}
+    render_bottombar(True, summary)

--- a/ui/bottombar.py
+++ b/ui/bottombar.py
@@ -9,8 +9,14 @@ def render_bottombar(open_state, summary):
     border = colors.get("border", "#eee")
     transition = THEME["drawer"]["transition_ms"]
 
-    fe, be = summary.get("FE", 0.0), summary.get("BE", 0.0)
-    fe_t, be_t = summary.get("FE_target", 1.0), summary.get("BE_target", 1.0)
+    def _num(val, default=0.0):
+        try:
+            return float(val)
+        except (TypeError, ValueError):
+            return default
+
+    fe, be = _num(summary.get("FE")), _num(summary.get("BE"))
+    fe_t, be_t = _num(summary.get("FE_target", 1.0), 1.0), _num(summary.get("BE_target", 1.0), 1.0)
     fe_ok = fe <= fe_t
     be_ok = be <= be_t
 


### PR DESCRIPTION
## Summary
- guard bottom bar FE/BE comparisons against string values
- record fix in changelog and bump version to 0.8.1
- add unit test ensuring string targets don't crash

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8bb3c3210833196410384dadfed7e