### PR TITLE
fix: show forms when adding income or debt

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,4 +1,4 @@
 """Project version information."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Replace deprecated `st.experimental_rerun` calls with `st.rerun` for Streamlit 1.27+ compatibility.
 - Missing income cards and overflowing disclosure box by restructuring layout with Streamlit columns.
 - Prevent type errors in bottom bar when FE/BE targets are provided as strings.
+- Blank drawer when adding income or debt cards due to incorrect editor state.
 
 ### Changed
 - Removed left data-entry column; main grid shows income, debts, and property boxes only.

--- a/tests/integration/test_cards_drawers.py
+++ b/tests/integration/test_cards_drawers.py
@@ -1,0 +1,24 @@
+import streamlit as st
+from core.scenarios import default_scenario
+from ui.cards_income import add_income_card
+from ui.cards_debts import add_debt_card
+from ui.sidebar_editor import render_context_form
+
+def _setup():
+    st.session_state.clear()
+    scn = default_scenario()
+    st.session_state["scenarios"] = {"Default": scn}
+    st.session_state["scenario_name"] = "Default"
+    return scn
+
+def test_add_income_card_drawer_renders():
+    scn = _setup()
+    cid = add_income_card(scn)
+    render_context_form(st.session_state["active_editor"], scn, [])
+    assert st.session_state["active_editor"] == {"kind": "income", "id": cid}
+
+def test_add_debt_card_drawer_renders():
+    scn = _setup()
+    cid = add_debt_card(scn)
+    render_context_form(st.session_state["active_editor"], scn, [])
+    assert st.session_state["active_editor"] == {"kind": "debt", "id": cid}

--- a/tests/unit/test_cards_binding.py
+++ b/tests/unit/test_cards_binding.py
@@ -7,7 +7,22 @@ def test_income_card_add_sets_active():
     st.session_state.clear()
     scn = {"income_cards": []}
     cid = add_income_card(scn)
-    assert st.session_state["active_editor"]["id"] == cid
+    assert st.session_state["active_editor"] == {"kind": "income", "id": cid}
+    assert st.session_state["drawer_open"] is True
+
+
+def test_select_income_card_sets_active():
+    st.session_state.clear()
+    select_income_card("xyz")
+    assert st.session_state["active_editor"] == {"kind": "income", "id": "xyz"}
+    assert st.session_state["drawer_open"] is True
+
+
+def test_add_debt_card_sets_active():
+    st.session_state.clear()
+    scn = {"debt_cards": []}
+    cid = add_debt_card(scn)
+    assert st.session_state["active_editor"] == {"kind": "debt", "id": cid}
     assert st.session_state["drawer_open"] is True
 
 

--- a/ui/cards_income.py
+++ b/ui/cards_income.py
@@ -8,13 +8,12 @@ import uuid
 def add_income_card(scn, typ="W-2"):
     cid = uuid.uuid4().hex[:8]
     scn.setdefault("income_cards", []).append({"id": cid, "type": typ, "payload": {}})
-    st.session_state["active_editor"] = {"kind": typ.lower(), "id": cid}
+    st.session_state["active_editor"] = {"kind": "income", "id": cid}
     st.session_state["drawer_open"] = True
     return cid
 
-
-def select_income_card(card_id, kind="income"):
-    st.session_state["active_editor"] = {"kind": kind, "id": card_id}
+def select_income_card(card_id):
+    st.session_state["active_editor"] = {"kind": "income", "id": card_id}
     st.session_state["drawer_open"] = True
 
 
@@ -25,4 +24,4 @@ def render_income_board(scn):
     for card in scn.get("income_cards", []):
         label = card.get("type", "Income")
         if st.button(f"{label}", key=f"inc_{card['id']}"):
-            select_income_card(card["id"], kind=label.lower())
+            select_income_card(card["id"])


### PR DESCRIPTION
## Summary
- ensure new income cards open the proper editor instead of a blank drawer
- cover income and debt drawer activation with unit and integration tests
- bump version to 0.8.2

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8bdd68d8c8331b0e83ecac99cb6d4