### PR TITLE
feat: move data-entry boards into sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,8 +22,8 @@ st.set_page_config(page_title="Aimlo", layout="wide")
 if "scenarios" not in st.session_state:
     st.session_state["scenarios"] = {"Default": default_scenario()}
     st.session_state["scenario_name"] = "Default"
-st.session_state.setdefault("drawer_open", False)
-st.session_state.setdefault("active_editor", None)
+st.session_state.setdefault("drawer_open", True)
+st.session_state.setdefault("active_editor", {"kind": "income_board"})
 st.session_state.setdefault("bottombar_visible", False)
 
 render_topbar()

--- a/core/version.py
+++ b/core/version.py
@@ -1,4 +1,4 @@
 """Project version information."""
 
-__version__ = "0.8.2"
+__version__ = "0.9.0"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,4 +20,5 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Removed left data-entry column; main grid shows income, debts, and property boxes only.
 - All data entry forms open in an overlay drawer with disclosures and guides.
+- Income, debt, and property boards now render inside the sidebar drawer with income board active by default.
 

--- a/tests/integration/test_drawers_smoke.py
+++ b/tests/integration/test_drawers_smoke.py
@@ -4,13 +4,15 @@ from ui.utils import show_sidebar, hide_sidebar, show_bottombar, hide_bottombar
 
 def test_drawers_smoke():
     st.session_state.clear()
-    assert st.session_state.get("drawer_open", False) is False
-    assert st.session_state.get("bottombar_visible", False) is False
-    show_sidebar()
-    show_bottombar()
+    st.session_state["drawer_open"] = True
+    st.session_state["bottombar_visible"] = False
     assert st.session_state["drawer_open"] is True
-    assert st.session_state["bottombar_visible"] is True
+    assert st.session_state["bottombar_visible"] is False
     hide_sidebar()
     hide_bottombar()
     assert st.session_state["drawer_open"] is False
     assert st.session_state["bottombar_visible"] is False
+    show_sidebar()
+    show_bottombar()
+    assert st.session_state["drawer_open"] is True
+    assert st.session_state["bottombar_visible"] is True

--- a/tests/unit/test_app_defaults.py
+++ b/tests/unit/test_app_defaults.py
@@ -1,0 +1,14 @@
+import streamlit as st
+from core.scenarios import default_scenario
+
+
+def test_app_defaults_open_sidebar():
+    st.session_state.clear()
+    if "scenarios" not in st.session_state:
+        st.session_state["scenarios"] = {"Default": default_scenario()}
+        st.session_state["scenario_name"] = "Default"
+    st.session_state.setdefault("drawer_open", True)
+    st.session_state.setdefault("active_editor", {"kind": "income_board"})
+    assert st.session_state["drawer_open"] is True
+    assert st.session_state["active_editor"] == {"kind": "income_board"}
+

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -1,15 +1,7 @@
 import streamlit as st
-from ui.cards_income import render_income_board
-from ui.cards_debts import render_debt_board
-from ui.panel_property import render_property_panel
 
 
 def render_layout(scn):
-    """Main three-column layout with income, debts, and property boxes."""
-    col_income, col_debts, col_prop = st.columns([1, 1, 1])
-    with col_income:
-        render_income_board(scn)
-    with col_debts:
-        render_debt_board(scn)
-    with col_prop:
-        render_property_panel(scn)
+    """Main content area; data entry now occurs in the sidebar drawer."""
+    st.empty()
+

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -7,6 +7,9 @@ from core.calculators import (
 )
 from ui.utils import borrower_selectbox
 from core.presets import CONV_MI_BANDS, FHA_TABLE, VA_TABLE, USDA_TABLE
+from ui.cards_income import render_income_board
+from ui.cards_debts import render_debt_board
+from ui.panel_property import render_property_panel
 
 HELP_MAP={
  "W-2":{"annual_salary":"Paystub YTD/Base; W-2 Box 1 context","hourly_rate":"Paystub rate","hours_per_week":"Offer/VOE","ot_ytd":"Paystub YTD OT","bonus_ytd":"Paystub YTD Bonus","comm_ytd":"Paystub YTD Commission","months_ytd":"Months covered by YTD","ot_ly":"W-2/Last Year OT","bonus_ly":"W-2/Last Year Bonus","comm_ly":"W-2/Last Year Comm","months_ly":"Months for LY variable"},
@@ -193,7 +196,15 @@ def render_property_editor(h):
     st.json({"Conventional_MI_bands":CONV_MI_BANDS,"FHA":FHA_TABLE,"VA":VA_TABLE,"USDA":USDA_TABLE})
 def render_context_form(active, scn, warnings):
     """Render the drawer content for the currently active editor."""
-    if active is None or active.get("kind") is None:
+    if active is None or active.get("kind") in {None, "income_board", "debt_board", "property_board"}:
+        kind = None if active is None else active.get("kind")
+        if kind in (None, "income_board"):
+            render_income_board(scn)
+        if kind in (None, "debt_board"):
+            render_debt_board(scn)
+        if kind in (None, "property_board"):
+            render_property_panel(scn)
+        st.markdown("---")
         render_disclosures(warnings)
         return
     if active["kind"] == "income_new":


### PR DESCRIPTION
## Summary
- relocate income, debt, and property boards from main layout to sidebar drawer and show income board by default
- default drawer open and tests updated for sidebar-centric data entry
## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a902fbc3b48331b0bd9d4b12127019