### PR TITLE
feat: open drawer by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ st.set_page_config(page_title="Aimlo", layout="wide")
 if "scenarios" not in st.session_state:
     st.session_state["scenarios"] = {"Default": default_scenario()}
     st.session_state["scenario_name"] = "Default"
-st.session_state.setdefault("drawer_open", False)
+st.session_state.setdefault("drawer_open", True)
 st.session_state.setdefault("active_editor", None)
 st.session_state.setdefault("bottombar_visible", False)
 

--- a/core/version.py
+++ b/core/version.py
@@ -1,4 +1,4 @@
 """Project version information."""
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,4 +20,5 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Removed left data-entry column; main grid shows income, debts, and property boxes only.
 - All data entry forms open in an overlay drawer with disclosures and guides.
+- Drawer opens by default on first load.
 

--- a/tests/integration/test_drawers_smoke.py
+++ b/tests/integration/test_drawers_smoke.py
@@ -4,7 +4,8 @@ from ui.utils import show_sidebar, hide_sidebar, show_bottombar, hide_bottombar
 
 def test_drawers_smoke():
     st.session_state.clear()
-    assert st.session_state.get("drawer_open", False) is False
+    st.session_state.setdefault("drawer_open", True)
+    assert st.session_state["drawer_open"] is True
     assert st.session_state.get("bottombar_visible", False) is False
     show_sidebar()
     show_bottombar()


### PR DESCRIPTION
## Summary
- default to open the sidebar drawer on initial load
- adjust drawer smoke test for new default state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9047ae6c48331ac673dc3df6ab421