### PR TITLE
feat: add sidebar toggle arrow

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.8.3"
+__version__ = "0.9.0"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Compact bottom summary drawer with snapshot totals.
 - Initial project scaffolding and mandatory metadata files.
 - Borrower sidebar cards for name, contact, and credit info with top bar dropdown selection.
+- Arrow toggle on sidebar header to open and close the drawer.
 
 ### Fixed
 - Install pytest in CI workflow to enable test execution.

--- a/tests/integration/test_drawers_smoke.py
+++ b/tests/integration/test_drawers_smoke.py
@@ -12,7 +12,7 @@ def test_drawers_smoke():
     show_bottombar()
 
     assert st.session_state["drawer_open"] is True
-    assert st.session_state["bottombar_visible"] is False
+    assert st.session_state["bottombar_visible"] is True
     hide_sidebar()
     hide_bottombar()
     assert st.session_state["drawer_open"] is False

--- a/tests/integration/test_visibility.py
+++ b/tests/integration/test_visibility.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from ui.utils import show_sidebar, hide_sidebar, show_bottombar, hide_bottombar
+from ui.utils import show_sidebar, hide_sidebar, show_bottombar, hide_bottombar, toggle_sidebar
 
 def test_visibility_sequence():
     st.session_state.clear()
@@ -7,6 +7,10 @@ def test_visibility_sequence():
     show_bottombar()
     assert st.session_state["drawer_open"]
     assert st.session_state["bottombar_visible"]
+    toggle_sidebar()
+    assert not st.session_state["drawer_open"]
+    toggle_sidebar()
+    assert st.session_state["drawer_open"]
     hide_sidebar()
     hide_bottombar()
     assert not st.session_state["drawer_open"]

--- a/tests/unit/test_ui_state.py
+++ b/tests/unit/test_ui_state.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from ui.utils import show_sidebar, hide_sidebar
+from ui.utils import show_sidebar, hide_sidebar, toggle_sidebar
 
 
 def test_drawer_state():
@@ -8,6 +8,15 @@ def test_drawer_state():
     assert st.session_state.get("drawer_open") is True
     hide_sidebar()
     assert st.session_state.get("drawer_open") is False
+
+
+def test_drawer_toggle():
+    st.session_state.clear()
+    st.session_state["drawer_open"] = False
+    toggle_sidebar()
+    assert st.session_state["drawer_open"] is True
+    toggle_sidebar()
+    assert st.session_state["drawer_open"] is False
 
 
 def test_active_editor_mutations():

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -5,7 +5,7 @@ from core.calculators import (
     w2_row_to_monthly, schc_rows_to_monthly, k1_rows_to_monthly, c1120_rows_to_monthly,
     rentals_schedule_e_monthly, rentals_75pct_gross_monthly, other_income_rows_to_monthly
 )
-from ui.utils import borrower_selectbox
+from ui.utils import borrower_selectbox, toggle_sidebar
 from core.presets import CONV_MI_BANDS, FHA_TABLE, VA_TABLE, USDA_TABLE
 from ui.cards_income import render_income_board
 from ui.cards_debts import render_debt_board
@@ -242,6 +242,22 @@ def render_drawer(scn, warnings=None):
     text = colors.get("panel_text", "#fff")
     border = colors.get("border", "#333")
     open_state = st.session_state.get("drawer_open", False)
+    toggle_left = width if open_state else 0
+    st.markdown(
+        f"""
+    <style>
+    #drawer_toggle{{position:fixed;top:70px;left:{toggle_left}px;z-index:1001;}}
+    #drawer_toggle button{{background:{bg};color:{text};border:none;}}
+    </style>
+    """,
+        unsafe_allow_html=True,
+    )
+    st.markdown("<div id='drawer_toggle'>", unsafe_allow_html=True)
+    arrow = "\u2190" if open_state else "\u2192"
+    if st.button(arrow, key="drawer_toggle_btn"):
+        toggle_sidebar()
+        st.rerun()
+    st.markdown("</div>", unsafe_allow_html=True)
     st.markdown(
         f"""
     <style>

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -7,6 +7,9 @@ def show_sidebar():
 def hide_sidebar():
     st.session_state["drawer_open"] = False
 
+def toggle_sidebar():
+    st.session_state["drawer_open"] = not st.session_state.get("drawer_open", False)
+
 def show_bottombar():
     st.session_state["bottombar_visible"] = True
 


### PR DESCRIPTION
## Summary
- add arrow button to toggle sidebar drawer visibility
- expose `toggle_sidebar` utility for reuse
- document toggle and bump version

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a91614d25483318bb621defd403b27