### PR TITLE
fix: restore main boards and widen sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,6 @@ st.set_page_config(page_title="Aimlo", layout="wide")
 if "scenarios" not in st.session_state:
     st.session_state["scenarios"] = {"Default": default_scenario()}
     st.session_state["scenario_name"] = "Default"
-st.session_state.setdefault("drawer_open", True)
 
 st.session_state.setdefault("active_editor", None)
 

--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to this project will be documented in this file.
 - Compact bottom summary drawer with snapshot totals.
 - Initial project scaffolding and mandatory metadata files.
 - Borrower sidebar cards for name, contact, and credit info with top bar dropdown selection.
-- Arrow toggle on sidebar header to open and close the drawer.
 
 ### Fixed
 - Install pytest in CI workflow to enable test execution.
@@ -18,11 +17,8 @@ All notable changes to this project will be documented in this file.
 - Prevent type errors in bottom bar when FE/BE targets are provided as strings.
 - Blank drawer when adding income or debt cards due to incorrect editor state.
 - Sidebar drawer rendered empty because widgets were outside the HTML container; content now uses Streamlit's sidebar.
+- Removed sidebar toggle arrow and restored income and debt boards to main layout with a wider persistent sidebar.
 
 ### Changed
 - Removed left data-entry column; main grid shows income, debts, and property boxes only.
-- All data entry forms open in an overlay drawer with disclosures and guides.
-
-- Drawer opens by default on first load.
-
-- Income, debt, and property boards now render inside the sidebar drawer with income board active by default.
+- Sidebar remains visible for data entry with disclosures and guides.

--- a/tests/integration/test_cards_drawers.py
+++ b/tests/integration/test_cards_drawers.py
@@ -1,7 +1,7 @@
 import streamlit as st
 from core.scenarios import default_scenario
-from ui.cards_income import add_income_card
-from ui.cards_debts import add_debt_card
+from ui.cards_income import add_income_card, select_income_card
+from ui.cards_debts import add_debt_card, select_debt_card
 from ui.sidebar_editor import render_context_form
 
 def _setup():
@@ -22,3 +22,14 @@ def test_add_debt_card_drawer_renders():
     cid = add_debt_card(scn)
     render_context_form(st.session_state["active_editor"], scn, [])
     assert st.session_state["active_editor"] == {"kind": "debt", "id": cid}
+
+def test_select_existing_cards():
+    scn = _setup()
+    inc_id = add_income_card(scn)
+    deb_id = add_debt_card(scn)
+    # reset active_editor
+    st.session_state["active_editor"] = None
+    select_income_card(inc_id)
+    assert st.session_state["active_editor"] == {"kind": "income", "id": inc_id}
+    select_debt_card(deb_id)
+    assert st.session_state["active_editor"] == {"kind": "debt", "id": deb_id}

--- a/tests/integration/test_drawer_content.py
+++ b/tests/integration/test_drawer_content.py
@@ -6,13 +6,11 @@ from core.scenarios import default_scenario
 from ui.sidebar_editor import render_drawer
 st.session_state.clear()
 scn = default_scenario()
-st.session_state['drawer_open'] = True
 st.session_state['active_editor'] = None
 render_drawer(scn)
 '''
 
-def test_drawer_shows_boards():
+def test_drawer_shows_placeholder():
     at = stt.AppTest.from_string(SCRIPT).run()
-    subheaders = [el.value for el in at.sidebar.subheader]
-    assert "All Income" in subheaders
-    assert "All Debts/Liabilities" in subheaders
+    infos = [el.value for el in at.sidebar.info]
+    assert "Select a card to edit" in infos

--- a/tests/unit/test_cards_binding.py
+++ b/tests/unit/test_cards_binding.py
@@ -8,14 +8,12 @@ def test_income_card_add_sets_active():
     scn = {"income_cards": []}
     cid = add_income_card(scn)
     assert st.session_state["active_editor"] == {"kind": "income", "id": cid}
-    assert st.session_state["drawer_open"] is True
 
 
 def test_select_income_card_sets_active():
     st.session_state.clear()
     select_income_card("xyz")
     assert st.session_state["active_editor"] == {"kind": "income", "id": "xyz"}
-    assert st.session_state["drawer_open"] is True
 
 
 def test_add_debt_card_sets_active():
@@ -23,7 +21,6 @@ def test_add_debt_card_sets_active():
     scn = {"debt_cards": []}
     cid = add_debt_card(scn)
     assert st.session_state["active_editor"] == {"kind": "debt", "id": cid}
-    assert st.session_state["drawer_open"] is True
 
 
 def test_select_debt_card_sets_active():
@@ -31,4 +28,3 @@ def test_select_debt_card_sets_active():
     scn = {"debt_cards": [{"id": "abc", "type": "installment", "name": "", "monthly_payment": 0.0}]}
     select_debt_card("abc")
     assert st.session_state["active_editor"] == {"kind": "debt", "id": "abc"}
-    assert st.session_state["drawer_open"] is True

--- a/ui/cards_debts.py
+++ b/ui/cards_debts.py
@@ -7,13 +7,11 @@ def add_debt_card(scn, typ="installment"):
     cid = uuid.uuid4().hex[:8]
     scn.setdefault("debt_cards", []).append({"id": cid, "type": typ, "name": "", "monthly_payment": 0.0})
     st.session_state["active_editor"] = {"kind": "debt", "id": cid}
-    st.session_state["drawer_open"] = True
     return cid
 
 
 def select_debt_card(card_id):
     st.session_state["active_editor"] = {"kind": "debt", "id": card_id}
-    st.session_state["drawer_open"] = True
 
 
 def render_debt_board(scn):

--- a/ui/cards_income.py
+++ b/ui/cards_income.py
@@ -9,12 +9,10 @@ def add_income_card(scn, typ="W-2"):
     cid = uuid.uuid4().hex[:8]
     scn.setdefault("income_cards", []).append({"id": cid, "type": typ, "payload": {}})
     st.session_state["active_editor"] = {"kind": "income", "id": cid}
-    st.session_state["drawer_open"] = True
     return cid
 
 def select_income_card(card_id):
     st.session_state["active_editor"] = {"kind": "income", "id": card_id}
-    st.session_state["drawer_open"] = True
 
 
 def render_income_board(scn):

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -1,7 +1,16 @@
 import streamlit as st
+from ui.cards_income import render_income_board
+from ui.cards_debts import render_debt_board
+from ui.panel_property import render_property_panel
 
 
 def render_layout(scn):
-    """Main content area; data entry now occurs in the sidebar drawer."""
-    st.empty()
+    """Render the main boards for income, debts, and property."""
+
+    render_property_panel(scn)
+    col_inc, col_deb = st.columns(2)
+    with col_inc:
+        render_income_board(scn)
+    with col_deb:
+        render_debt_board(scn)
 

--- a/ui/panel_property.py
+++ b/ui/panel_property.py
@@ -11,5 +11,4 @@ def render_property_panel(scn):
     st.write(f"Price ${price:,.0f} | DP ${dp:,.0f} | Rate {rate:.3f}% | Term {term}y")
     if st.button("Edit property & program (open sidebar)"):
         st.session_state["active_editor"] = {"kind": "property", "id": "housing"}
-        st.session_state["drawer_open"] = True
-        st.experimental_rerun()
+        st.rerun()

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -5,11 +5,8 @@ from core.calculators import (
     w2_row_to_monthly, schc_rows_to_monthly, k1_rows_to_monthly, c1120_rows_to_monthly,
     rentals_schedule_e_monthly, rentals_75pct_gross_monthly, other_income_rows_to_monthly
 )
-from ui.utils import borrower_selectbox, toggle_sidebar
+from ui.utils import borrower_selectbox
 from core.presets import CONV_MI_BANDS, FHA_TABLE, VA_TABLE, USDA_TABLE
-from ui.cards_income import render_income_board
-from ui.cards_debts import render_debt_board
-from ui.panel_property import render_property_panel
 
 HELP_MAP={
  "W-2":{"annual_salary":"Paystub YTD/Base; W-2 Box 1 context","hourly_rate":"Paystub rate","hours_per_week":"Offer/VOE","ot_ytd":"Paystub YTD OT","bonus_ytd":"Paystub YTD Bonus","comm_ytd":"Paystub YTD Commission","months_ytd":"Months covered by YTD","ot_ly":"W-2/Last Year OT","bonus_ly":"W-2/Last Year Bonus","comm_ly":"W-2/Last Year Comm","months_ly":"Months for LY variable"},
@@ -195,15 +192,9 @@ def render_property_editor(h):
     st.markdown("---"); st.markdown("### Program Tables (MI/MIP/Fees)"); st.caption("Edit defaults as needed (Conventional MI bands, FHA/VA/USDA upfront & annual).")
     st.json({"Conventional_MI_bands":CONV_MI_BANDS,"FHA":FHA_TABLE,"VA":VA_TABLE,"USDA":USDA_TABLE})
 def render_context_form(active, scn, warnings):
-    """Render the drawer content for the currently active editor."""
-    if active is None or active.get("kind") in {None, "income_board", "debt_board", "property_board"}:
-        kind = None if active is None else active.get("kind")
-        if kind in (None, "income_board"):
-            render_income_board(scn)
-        if kind in (None, "debt_board"):
-            render_debt_board(scn)
-        if kind in (None, "property_board"):
-            render_property_panel(scn)
+    """Render the sidebar content for the currently active editor."""
+    if active is None:
+        st.info("Select a card to edit")
         st.markdown("---")
         render_disclosures(warnings)
         return
@@ -232,43 +223,16 @@ def render_context_form(active, scn, warnings):
     render_disclosures(warnings)
 
 def render_drawer(scn, warnings=None):
-    """Render the editor drawer using Streamlit's built-in sidebar.
+    """Render the editor sidebar permanently on screen."""
 
-    The previous implementation attempted to build a custom drawer with raw
-    HTML. Streamlit renders each element in its own root container, so the
-    sidebar HTML wrapper ended up empty, leaving the drawer blank. By using
-    `st.sidebar` as the container we ensure all widgets appear correctly.
-    """
     warnings = warnings or []
-    open_state = st.session_state.get("drawer_open", False)
-
-    # Toggle button lives in the main area
-    arrow = "\u2190" if open_state else "\u2192"
-    if st.button(arrow, key="drawer_toggle_btn"):
-        toggle_sidebar()
-        st.rerun()
-
-    if not open_state:
-        # Hide sidebar when closed
-        st.sidebar.empty()
-        st.markdown(
-            "<style>div[data-testid='stSidebar']{display:none;}</style>",
-            unsafe_allow_html=True,
-        )
-        return
-
-    # Ensure sidebar is visible and themed
     colors = THEME["colors"]
     bg = colors.get("panel_bg", "#222")
     text = colors.get("panel_text", "#fff")
     st.markdown(
-        f"<style>div[data-testid='stSidebar']{{display:block;background:{bg};color:{text};}}</style>",
+        f"<style>div[data-testid='stSidebar']{{width:600px;background:{bg};color:{text};}}</style>",
         unsafe_allow_html=True,
     )
 
     with st.sidebar:
-        if st.button("✕", key="drawer_close"):
-            st.session_state["drawer_open"] = False
-            st.session_state["active_editor"] = None
-            st.rerun()
         render_context_form(st.session_state.get("active_editor"), scn, warnings)

--- a/ui/topbar.py
+++ b/ui/topbar.py
@@ -21,7 +21,6 @@ def render_topbar():
             st.session_state["selected_borrower"] = next((bid for bid, nm in id_map.items() if nm == chosen), current_id)
             if st.button("Borrowers", key="tb_br_manage"):
                 st.session_state["active_editor"] = {"kind": "borrowers", "id": None}
-                st.session_state["drawer_open"] = True
                 st.rerun()
         with c3:
             colA,colB,colC=st.columns(3)


### PR DESCRIPTION
## Summary
- Restore income and debt boards to the main layout
- Remove drawer toggle and make sidebar always visible at double width
- Update tests and documentation; bump version to 0.9.2

## Testing
- `pytest`

Unable to capture screenshot in this environment (Playwright browser download blocked).

------
https://chatgpt.com/codex/tasks/task_e_68a91a80245883319e70af9e9804057d