### PR TITLE
feat: double sidebar width

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,3 +22,4 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Removed left data-entry column; main grid shows income, debts, and property boxes only.
 - Sidebar remains visible for data entry with disclosures and guides.
+- Doubled sidebar width for expanded editing space.

--- a/tests/unit/test_sidebar_width.py
+++ b/tests/unit/test_sidebar_width.py
@@ -1,0 +1,27 @@
+import streamlit as st
+from ui import sidebar_editor
+
+
+def test_sidebar_width_css(monkeypatch):
+    # Capture markdown calls to inspect applied CSS
+    calls = []
+
+    def fake_markdown(body, *args, **kwargs):
+        calls.append(body)
+
+    monkeypatch.setattr(st, "markdown", fake_markdown)
+    # Avoid rendering the full context form
+    monkeypatch.setattr(sidebar_editor, "render_context_form", lambda *a, **k: None)
+
+    class DummySidebar:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(st, "sidebar", DummySidebar())
+
+    sidebar_editor.render_drawer({}, warnings=[])
+
+    assert any("width:1200px" in c for c in calls)

--- a/ui/layout_helpers.py
+++ b/ui/layout_helpers.py
@@ -1,7 +1,7 @@
 """Helper functions for layout styling."""
 from __future__ import annotations
 
-SIDEBAR_WIDTH = 260
+SIDEBAR_WIDTH = 520
 
 
 def build_sidebar_css(panel_bg: str, panel_text: str, visible: bool, width: int = SIDEBAR_WIDTH) -> str:

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -230,7 +230,7 @@ def render_drawer(scn, warnings=None):
     bg = colors.get("panel_bg", "#222")
     text = colors.get("panel_text", "#fff")
     st.markdown(
-        f"<style>div[data-testid='stSidebar']{{width:600px;background:{bg};color:{text};}}</style>",
+        f"<style>div[data-testid='stSidebar']{{width:1200px;background:{bg};color:{text};}}</style>",
         unsafe_allow_html=True,
     )
 


### PR DESCRIPTION
## Summary
- double sidebar width for expanded editing space
- adjust layout helper constant
- test updated for sidebar width
- bump version to 0.9.3

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a91d31d5cc83319d4b7c79b64254c1