### PR TITLE
fix: apply consistent sidebar width

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Blank drawer when adding income or debt cards due to incorrect editor state.
 - Sidebar drawer rendered empty because widgets were outside the HTML container; content now uses Streamlit's sidebar.
 - Removed sidebar toggle arrow and restored income and debt boards to main layout with a wider persistent sidebar.
+- Sidebar editor width now doubles `SIDEBAR_WIDTH` using the updated `section[data-testid='stSidebar']` selector for consistency.
 
 ### Changed
 - Removed left data-entry column; main grid shows income, debts, and property boxes only.

--- a/tests/unit/test_sidebar_width.py
+++ b/tests/unit/test_sidebar_width.py
@@ -1,0 +1,29 @@
+import streamlit as st
+import ui.sidebar_editor as sidebar_editor
+from ui.layout_helpers import SIDEBAR_WIDTH
+
+
+def test_sidebar_drawer_width(monkeypatch):
+    captured = {}
+
+    def fake_markdown(html, unsafe_allow_html=False):
+        captured['html'] = html
+
+    monkeypatch.setattr(st, 'markdown', fake_markdown)
+
+    class DummySidebar:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    monkeypatch.setattr(st, 'sidebar', DummySidebar())
+    monkeypatch.setattr(sidebar_editor, 'render_context_form', lambda *a, **k: None)
+    st.session_state.clear()
+    sidebar_editor.render_drawer({})
+
+    width = SIDEBAR_WIDTH * 2
+    assert "section[data-testid='stSidebar']" in captured['html']
+    assert f"width:{width}px" in captured['html']
+    assert f"max-width:{width}px" in captured['html']

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -7,6 +7,7 @@ from core.calculators import (
 )
 from ui.utils import borrower_selectbox
 from core.presets import CONV_MI_BANDS, FHA_TABLE, VA_TABLE, USDA_TABLE
+from ui.layout_helpers import SIDEBAR_WIDTH
 
 HELP_MAP={
  "W-2":{"annual_salary":"Paystub YTD/Base; W-2 Box 1 context","hourly_rate":"Paystub rate","hours_per_week":"Offer/VOE","ot_ytd":"Paystub YTD OT","bonus_ytd":"Paystub YTD Bonus","comm_ytd":"Paystub YTD Commission","months_ytd":"Months covered by YTD","ot_ly":"W-2/Last Year OT","bonus_ly":"W-2/Last Year Bonus","comm_ly":"W-2/Last Year Comm","months_ly":"Months for LY variable"},
@@ -229,8 +230,10 @@ def render_drawer(scn, warnings=None):
     colors = THEME["colors"]
     bg = colors.get("panel_bg", "#222")
     text = colors.get("panel_text", "#fff")
+    width = SIDEBAR_WIDTH * 2
     st.markdown(
-        f"<style>div[data-testid='stSidebar']{{width:600px;background:{bg};color:{text};}}</style>",
+        f"<style>section[data-testid='stSidebar']{{width:{width}px !important;max-width:{width}px !important;"
+        f"background:{bg};color:{text};}}</style>",
         unsafe_allow_html=True,
     )
 


### PR DESCRIPTION
## Summary
- double sidebar drawer width using `SIDEBAR_WIDTH`
- target new `section[data-testid='stSidebar']` selector
- test sidebar width is computed from layout constant

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a91fbf9af483319a03dd9e4381104a