### PR TITLE
fix: place property panel in third column

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.9.3"
+__version__ = "0.9.4"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Sidebar drawer rendered empty because widgets were outside the HTML container; content now uses Streamlit's sidebar.
 - Removed sidebar toggle arrow and restored income and debt boards to main layout with a wider persistent sidebar.
 - Sidebar editor width now doubles `SIDEBAR_WIDTH` using the updated `section[data-testid='stSidebar']` selector for consistency.
+- Property info panel now renders in a third column to the right of debts.
 
 ### Changed
 - Removed left data-entry column; main grid shows income, debts, and property boxes only.

--- a/tests/integration/test_layout_smoke.py
+++ b/tests/integration/test_layout_smoke.py
@@ -1,12 +1,37 @@
 import streamlit as st
-from ui.layout import render_layout
+import ui.layout as layout
 from ui.utils import show_bottombar, hide_bottombar
 
 
-def test_layout_smoke():
+def test_layout_smoke(monkeypatch):
     st.session_state.clear()
     scn = {"income_cards": [], "debt_cards": [], "housing": {}}
-    render_layout(scn)
+
+    col_meta = {}
+
+    def fake_columns(spec):
+        col_meta["n"] = len(spec) if isinstance(spec, (list, tuple)) else spec
+        class DummyCol:
+            def __enter__(self):
+                return self
+            def __exit__(self, exc_type, exc, tb):
+                return False
+        return DummyCol(), DummyCol(), DummyCol()
+
+    monkeypatch.setattr(st, "columns", fake_columns)
+
+    prop_called = {"called": False}
+
+    def fake_render_property_panel(scn):
+        prop_called["called"] = True
+
+    monkeypatch.setattr(layout, "render_property_panel", fake_render_property_panel)
+
+    layout.render_layout(scn)
+
+    assert col_meta["n"] == 3
+    assert prop_called["called"] is True
+
     show_bottombar()
     assert st.session_state["bottombar_visible"] is True
     hide_bottombar()

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -6,11 +6,11 @@ from ui.panel_property import render_property_panel
 
 def render_layout(scn):
     """Render the main boards for income, debts, and property."""
-
-    render_property_panel(scn)
-    col_inc, col_deb = st.columns(2)
+    col_inc, col_deb, col_prop = st.columns([2, 2, 1])
     with col_inc:
         render_income_board(scn)
     with col_deb:
         render_debt_board(scn)
+    with col_prop:
+        render_property_panel(scn)
 


### PR DESCRIPTION
## Summary
- render property info beside income and debt boards using three-column layout
- cover layout with integration test
- document and bump patch version

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9221c66508331863ecafa1fc24675