### PR TITLE
feat: expand income and debt card details

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.9.4"
+__version__ = "0.10.0"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Compact bottom summary drawer with snapshot totals.
 - Initial project scaffolding and mandatory metadata files.
 - Borrower sidebar cards for name, contact, and credit info with top bar dropdown selection.
+- Income and debt cards now display borrower, type, employer/title, and monthly totals.
 
 ### Fixed
 - Install pytest in CI workflow to enable test execution.

--- a/tests/unit/test_card_totals.py
+++ b/tests/unit/test_card_totals.py
@@ -1,0 +1,10 @@
+import ui.cards_income as ci
+import ui.cards_debts as cd
+
+def test_income_monthly_w2():
+    card = {"type": "W-2", "payload": {"annual_salary": 120000, "pay_type": "Salary"}}
+    assert ci.income_monthly(card) == 10000.0
+
+def test_debt_monthly_student_loan():
+    card = {"type": "student_loan", "sl_balance": 50000.0, "sl_documented_payment": 0.0, "sl_amortizing": False}
+    assert cd.debt_monthly(card, "Conventional") == 500.0

--- a/ui/cards_debts.py
+++ b/ui/cards_debts.py
@@ -1,11 +1,15 @@
 """Debt cards board and helpers."""
 import streamlit as st
 import uuid
+from core.calculators import student_loan_payment
+from ui.utils import borrower_name
 
 
 def add_debt_card(scn, typ="installment"):
     cid = uuid.uuid4().hex[:8]
-    scn.setdefault("debt_cards", []).append({"id": cid, "type": typ, "name": "", "monthly_payment": 0.0})
+    scn.setdefault("debt_cards", []).append(
+        {"id": cid, "borrower_id": 1, "type": typ, "name": "", "monthly_payment": 0.0}
+    )
     st.session_state["active_editor"] = {"kind": "debt", "id": cid}
     return cid
 
@@ -14,11 +18,29 @@ def select_debt_card(card_id):
     st.session_state["active_editor"] = {"kind": "debt", "id": card_id}
 
 
+def debt_monthly(card: dict, policy: str) -> float:
+    if card.get("type") == "student_loan":
+        return student_loan_payment(
+            policy,
+            card.get("sl_balance", 0.0),
+            card.get("sl_documented_payment", 0.0),
+            bool(card.get("sl_amortizing", False)),
+        )
+    return float(card.get("monthly_payment", 0.0))
+
+
 def render_debt_board(scn):
     st.subheader("All Debts/Liabilities")
     if st.button("Add debt card"):
         add_debt_card(scn)
+    policy = scn.get("settings", {}).get("student_loan_policy", "Conventional")
     for card in scn.get("debt_cards", []):
-        label = card.get("name") or card.get("type", "Debt")
-        if st.button(f"{label}", key=f"deb_{card['id']}"):
-            select_debt_card(card["id"])
+        name = borrower_name(scn, int(card.get("borrower_id", 1)))
+        monthly = debt_monthly(card, policy)
+        with st.container(border=True):
+            st.markdown(f"**Borrower:** {name}")
+            st.markdown(f"**Type:** {card.get('type', '')}")
+            st.markdown(f"**Title:** {card.get('name', '')}")
+            st.markdown(f"**Monthly:** ${monthly:,.2f}")
+            if st.button("Edit", key=f"deb_{card['id']}"):
+                select_debt_card(card["id"])

--- a/ui/cards_income.py
+++ b/ui/cards_income.py
@@ -1,8 +1,16 @@
-import streamlit as st
-
 """Income cards board and helpers."""
 import streamlit as st
 import uuid
+from core.calculators import (
+    w2_row_to_monthly,
+    schc_rows_to_monthly,
+    k1_rows_to_monthly,
+    c1120_rows_to_monthly,
+    rentals_schedule_e_monthly,
+    rentals_75pct_gross_monthly,
+    other_income_rows_to_monthly,
+)
+from ui.utils import borrower_name
 
 
 def add_income_card(scn, typ="W-2"):
@@ -11,8 +19,31 @@ def add_income_card(scn, typ="W-2"):
     st.session_state["active_editor"] = {"kind": "income", "id": cid}
     return cid
 
+
 def select_income_card(card_id):
     st.session_state["active_editor"] = {"kind": "income", "id": card_id}
+
+
+def income_monthly(card: dict) -> float:
+    t = card.get("type")
+    p = card.get("payload", {})
+    if t == "W-2":
+        return w2_row_to_monthly(p)
+    if t == "Schedule C":
+        return schc_rows_to_monthly([p])
+    if t == "K-1":
+        return k1_rows_to_monthly([p])
+    if t == "1120":
+        return c1120_rows_to_monthly([p])
+    if t == "Rental":
+        if p.get("method") == "Schedule E":
+            return rentals_schedule_e_monthly(p.get("lines", []))
+        return rentals_75pct_gross_monthly(p.get("gross_rents_annual", 0.0)) + (
+            0.75 * float(p.get("subject_market_rent", 0.0)) - float(p.get("subject_pitia", 0.0))
+        )
+    if t == "Other":
+        return other_income_rows_to_monthly([p])
+    return 0.0
 
 
 def render_income_board(scn):
@@ -20,6 +51,20 @@ def render_income_board(scn):
     if st.button("Add income card"):
         add_income_card(scn)
     for card in scn.get("income_cards", []):
-        label = card.get("type", "Income")
-        if st.button(f"{label}", key=f"inc_{card['id']}"):
-            select_income_card(card["id"])
+        p = card.get("payload", {})
+        name = borrower_name(scn, int(p.get("borrower_id", 1)))
+        employer = (
+            p.get("employer")
+            or p.get("business_name")
+            or p.get("entity_name")
+            or p.get("corp_name")
+            or ""
+        )
+        monthly = income_monthly(card)
+        with st.container(border=True):
+            st.markdown(f"**Borrower:** {name}")
+            st.markdown(f"**Type:** {card.get('type', '')}")
+            st.markdown(f"**Employer:** {employer}")
+            st.markdown(f"**Monthly:** ${monthly:,.2f}")
+            if st.button("Edit", key=f"inc_{card['id']}"):
+                select_income_card(card["id"])

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -29,3 +29,9 @@ def borrower_selectbox(label: str, current_id: int, key: str) -> int:
     current_name = id_map.get(current_id, names[0] if names else "")
     chosen = st.selectbox(label, names, index=names.index(current_name), key=key)
     return next((bid for bid, nm in id_map.items() if nm == chosen), current_id)
+
+
+def borrower_name(scn: dict, borrower_id: int) -> str:
+    """Return formatted borrower full name for the given ID."""
+    b = scn.get("borrowers", {}).get(borrower_id, {})
+    return f"{b.get('first_name', '')} {b.get('last_name', '')}".strip() or "Borrower"


### PR DESCRIPTION
## Summary
- show borrower, type, employer/title, and monthly total on income and debt cards
- add helpers to compute per-card monthly values
- cover new helpers with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9242caa9c83319060ed2595ebcd77