### PR TITLE
fix: remove deprecated experimental rerun

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,7 +82,7 @@ render_bottombar(st.session_state["bottombar_visible"], summary)
 if not st.session_state["bottombar_visible"]:
     if st.button("\u25b2", key="bottombar_show"):
         show_bottombar()
-        st.experimental_rerun()
+        st.rerun()
 
 # Render drawer last
 render_drawer(scn)

--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - Scrollable container layout with bottom bar document checklist.
 - Sidebar and bottom bar toggle arrows with dark gray styling.
 - Sidebar headers now appear inside their bordered boxes for clearer grouping.
-- Replace deprecated `st.experimental_rerun` calls with `st.rerun` for Streamlit 1.27+ compatibility.
+- Replace remaining deprecated `st.experimental_rerun` call with `st.rerun` for Streamlit 1.27+ compatibility.
 - Missing income cards and overflowing disclosure box by restructuring layout with Streamlit columns.
 - Prevent type errors in bottom bar when FE/BE targets are provided as strings.
 - Blank drawer when adding income or debt cards due to incorrect editor state.

--- a/tests/unit/test_deprecated_rerun.py
+++ b/tests/unit/test_deprecated_rerun.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_no_experimental_rerun():
+    """Ensure deprecated Streamlit rerun API is absent."""
+    assert "experimental_rerun" not in Path("app.py").read_text()
+


### PR DESCRIPTION
## Summary
- replace deprecated `st.experimental_rerun` with `st.rerun`
- ensure project version is 0.10.1
- test absence of deprecated rerun API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9257250748331aa994c55787dee1f