### PR TITLE
feat: allow selecting income card types

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Initial project scaffolding and mandatory metadata files.
 - Borrower sidebar cards for name, contact, and credit info with top bar dropdown selection.
 - Income and debt cards now display borrower, type, employer/title, and monthly totals.
+- Income card creation now allows selecting the income type instead of defaulting to W-2 only.
 
 ### Fixed
 - Install pytest in CI workflow to enable test execution.

--- a/tests/integration/test_cards_drawers.py
+++ b/tests/integration/test_cards_drawers.py
@@ -33,3 +33,16 @@ def test_select_existing_cards():
     assert st.session_state["active_editor"] == {"kind": "income", "id": inc_id}
     select_debt_card(deb_id)
     assert st.session_state["active_editor"] == {"kind": "debt", "id": deb_id}
+
+
+def test_create_non_w2_income_from_selector(monkeypatch):
+    scn = _setup()
+    st.session_state["active_editor"] = {"kind": "income_new"}
+    st.session_state["new_income_typ"] = "K-1"
+    monkeypatch.setattr(st, "button", lambda label, **kwargs: True if label == "Create income card" else False)
+    monkeypatch.setattr(st, "selectbox", lambda label, options, key=None, **kwargs: st.session_state.get(key, options[0]))
+    monkeypatch.setattr(st, "rerun", lambda: None)
+    render_context_form(st.session_state["active_editor"], scn, [])
+    assert scn["income_cards"] and scn["income_cards"][0]["type"] == "K-1"
+    new_id = scn["income_cards"][0]["id"]
+    assert st.session_state["active_editor"] == {"kind": "income", "id": new_id}

--- a/tests/unit/test_cards_binding.py
+++ b/tests/unit/test_cards_binding.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from ui.cards_income import add_income_card, select_income_card
+from ui.cards_income import add_income_card, select_income_card, render_income_board
 from ui.cards_debts import add_debt_card, select_debt_card
 
 
@@ -28,3 +28,11 @@ def test_select_debt_card_sets_active():
     scn = {"debt_cards": [{"id": "abc", "type": "installment", "name": "", "monthly_payment": 0.0}]}
     select_debt_card("abc")
     assert st.session_state["active_editor"] == {"kind": "debt", "id": "abc"}
+
+
+def test_render_income_board_sets_new(monkeypatch):
+    st.session_state.clear()
+    scn = {"income_cards": []}
+    monkeypatch.setattr(st, "button", lambda label, **kwargs: True)
+    render_income_board(scn)
+    assert st.session_state["active_editor"] == {"kind": "income_new"}

--- a/ui/cards_income.py
+++ b/ui/cards_income.py
@@ -49,7 +49,7 @@ def income_monthly(card: dict) -> float:
 def render_income_board(scn):
     st.subheader("All Income")
     if st.button("Add income card"):
-        add_income_card(scn)
+        st.session_state["active_editor"] = {"kind": "income_new"}
     for card in scn.get("income_cards", []):
         p = card.get("payload", {})
         name = borrower_name(scn, int(p.get("borrower_id", 1)))

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -46,8 +46,9 @@ def render_income_new(scn):
           "Rental":{"borrower_id":1,"method":"Schedule E","lines":[{"id":_id(),"borrower_id":1,"property":"","year":2024,"rents":0.0,"expenses":0.0,"depreciation":0.0}],"gross_rents_annual":0.0,"subject_market_rent":0.0,"subject_pitia":0.0},
           "Other":{"borrower_id":1,"type":"Social Security","gross_monthly":0.0,"gross_up_pct":0.0,"continuance_3yr":False},
         }
-        scn["income_cards"].append({"id":cid,"type":typ,"payload":defaults[typ]})
-        st.session_state["selected"]={"kind":"income","id":cid}; st.rerun()
+        scn.setdefault("income_cards", []).append({"id":cid,"type":typ,"payload":defaults[typ]})
+        st.session_state["active_editor"] = {"kind":"income","id":cid}
+        st.rerun()
 def render_debt_new(scn):
     typ = st.selectbox("Debt type", ["installment","revolving","student_loan","support"], key="new_debt_typ")
     if st.button("Create debt card"):


### PR DESCRIPTION
## Summary
- let users choose income type when adding an income card instead of defaulting to W-2
- fix sidebar income creation to set the active editor for the new card
- cover income type selection with unit and integration tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a92f216a048331bd2deb77c5e133cf