### PR TITLE
feat: display dashboard summary metrics

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Sticky summary band beneath top bar with snapshot totals.
+- Dashboard metrics surface Total Income, PITIA, FE DTI, and BE DTI.
 - Initial project scaffolding and mandatory metadata files.
 - Borrower sidebar cards for name, contact, and credit info with top bar dropdown selection.
 - Income and debt cards now display borrower, type, employer/title, and monthly totals.
@@ -26,3 +27,4 @@ All notable changes to this project will be documented in this file.
 - Removed left data-entry column; main grid shows income, debts, and property boxes only.
 - Sidebar remains visible for data entry with disclosures and guides.
 - Replaced bottom summary drawer with top summary band.
+- Dashboard DTI metrics show "—" when income is missing instead of extreme percentages.

--- a/tests/unit/test_dashboard_metrics.py
+++ b/tests/unit/test_dashboard_metrics.py
@@ -1,0 +1,71 @@
+import streamlit as st
+from ui.tabs_dashboard import render_dashboard
+from streamlit.delta_generator import DeltaGenerator
+
+
+def test_dashboard_metrics_zero_income(monkeypatch):
+    captured = {}
+
+    def fake_metric(self, label, value, *a, **k):
+        captured[label] = value
+
+    monkeypatch.setattr(DeltaGenerator, "metric", fake_metric)
+
+    # suppress non-essential Streamlit calls
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+    monkeypatch.setattr(st, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(st, "info", lambda *a, **k: None)
+    monkeypatch.setattr(st, "checkbox", lambda *a, **k: False)
+    monkeypatch.setattr(st, "write", lambda *a, **k: None)
+    monkeypatch.setattr(st, "caption", lambda *a, **k: None)
+    monkeypatch.setattr(st, "download_button", lambda *a, **k: None)
+
+    st.session_state.clear()
+    summary = {
+        "TotalIncome": 0.0,
+        "PITIA": 3329.95,
+        "FE": 0.5,
+        "BE": 0.6,
+        "FE_target": 0.31,
+        "BE_target": 0.43,
+    }
+
+    render_dashboard(summary, {}, [], "Test")
+
+    assert captured["Total Income"] == "$0.00"
+    assert captured["PITIA"] == "$3,329.95"
+    assert captured["FE DTI"] == "—"
+    assert captured["BE DTI"] == "—"
+
+
+def test_dashboard_metrics_percent(monkeypatch):
+    captured = {}
+
+    def fake_metric(self, label, value, *a, **k):
+        captured[label] = value
+
+    monkeypatch.setattr(DeltaGenerator, "metric", fake_metric)
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+    monkeypatch.setattr(st, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(st, "info", lambda *a, **k: None)
+    monkeypatch.setattr(st, "checkbox", lambda *a, **k: False)
+    monkeypatch.setattr(st, "write", lambda *a, **k: None)
+    monkeypatch.setattr(st, "caption", lambda *a, **k: None)
+    monkeypatch.setattr(st, "download_button", lambda *a, **k: None)
+
+    st.session_state.clear()
+    summary = {
+        "TotalIncome": 5000.0,
+        "PITIA": 1500.0,
+        "FE": 0.3,
+        "BE": 0.4,
+        "FE_target": 0.31,
+        "BE_target": 0.43,
+    }
+
+    render_dashboard(summary, {}, [], "Test")
+
+    assert captured["FE DTI"] == "30.00%"
+    assert captured["BE DTI"] == "40.00%"

--- a/ui/tabs_dashboard.py
+++ b/ui/tabs_dashboard.py
@@ -4,10 +4,16 @@ from core.presets import DISCLAIMER
 def render_dashboard(summary: dict, flags: dict, checklist: list, scenario_name: str):
     st.header(f"Dashboard — {scenario_name}")
     c1,c2,c3,c4=st.columns(4)
-    c1.metric("Total Income", f"${summary.get('TotalIncome',0):,.2f}")
+    income=float(summary.get('TotalIncome',0) or 0)
+    c1.metric("Total Income", f"${income:,.2f}")
     c2.metric("PITIA", f"${summary.get('PITIA',0):,.2f}")
-    c3.metric("FE DTI", f"{summary.get('FE',0.0):.2%}")
-    c4.metric("BE DTI", f"{summary.get('BE',0.0):.2%}")
+    if income<=0:
+        fe_str=be_str="—"
+    else:
+        fe_str=f"{summary.get('FE',0.0):.2%}"
+        be_str=f"{summary.get('BE',0.0):.2%}"
+    c3.metric("FE DTI", fe_str)
+    c4.metric("BE DTI", be_str)
     state={"totals":{"total_income":summary.get("TotalIncome",0.0),"housing_total":summary.get("PITIA",0.0),"other_debts":summary.get("OtherDebts",0.0),"fe":summary.get("FE",0.0),"be":summary.get("BE",0.0),"fe_target":summary.get("FE_target",1.0),"be_target":summary.get("BE_target",1.0)},"flags":flags}
     rules=evaluate_rules(state)
     st.subheader("Warnings & Findings")


### PR DESCRIPTION
## Summary
- show Total Income, PITIA, FE DTI and BE DTI metrics at top of dashboard
- mask FE/BE DTI metrics with "—" when no income is provided
- document dashboard metrics and bump version

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a93076a0748331b48cd326c5d0d4d5