### PR TITLE
feat: scaffold guidance system

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,5 +1,5 @@
 # AGENT.md — AMALO Engineering Agent Playbook
-**Date:** 2025-08-22
+**Date:** 2025-08-23
 
 This file defines how the autonomous agent (and human contributors) plan, implement, test, and release changes to the **AMALO** mortgage app. It encodes the standards required for reliability, clarity, and MLO-first usability.
 
@@ -17,7 +17,7 @@ AMALO is the **primary qualification tool** for a Florida Mortgage Loan Originat
 ---
 
 ## 2) Non‑Negotiable Principles
-1) **Explain fields**: All user-facing field help lives in `docs/field_hints.yml`. The app’s **Guidance Center** reads it at runtime. No new field without an entry here.
+1) **Explain fields & warnings**: All user-facing field help and rule text live in `docs/field_hints.yml` and `docs/rulebook.yml`. The app’s **Guidance Panel** reads them at runtime. No new field or rule without an entry here.
 2) **No regressions**: Every PR that changes logic adds tests (unit + at least one integration). **Golden scenarios** must remain green.
 3) **Visible version**: `core/version.py` defines `__version__ = "MAJOR.MINOR.PATCH"`. The top bar shows `AMALO — v{__version__}`.
 4) **Change is tracked**: `docs/CHANGELOG.md` (Keep a Changelog). Each PR updates the **Unreleased** section.
@@ -32,6 +32,7 @@ app.py
 /core/
   calculators.py
   rules.py
+  guidance.py
   presets.py
   models.py
   scenarios.py
@@ -43,6 +44,7 @@ app.py
   sidebar_editor.py
   bottombar.py
   tabs_dashboard.py
+  guidance_panel.py
 /export/
   pdf_export.py
 /tests/
@@ -55,6 +57,7 @@ app.py
   SCENARIOS.md
   CHANGELOG.md
   field_hints.yml
+  rulebook.yml
   CONTRIBUTING.md
 .github/
   workflows/ci.yml
@@ -76,6 +79,7 @@ app.py
 - **Tests added/updated** (unit + at least one integration path). Golden scenarios updated only if expected outputs intentionally change.
 - `docs/CHANGELOG.md` updated (under **Unreleased**).
 - `docs/field_hints.yml` updated for any new/changed field.
+- `docs/rulebook.yml` updated for any new/changed rule text.
 - `core/version.py` bumped (SemVer: patch=fix, minor=feature, major=breaking).
 - Top bar displays the new version automatically.
 - App launches; no critical rules broken; CI green.
@@ -101,7 +105,7 @@ app.py
 ## 8) UX & Explainability Rules
 - Input = **forms** inside cards; no raw editable tables for data entry.
 - Each field shows label + sublabel pulled from `docs/field_hints.yml`.
-- **Guidance Center** side panel provides a 3-way toggle: **Guides**, **Warnings**, **Where to find**.
+- Sticky **Guidance Panel** under the summary band provides tabs: **Disclosures**, **Guides**, **Warnings**, **Where to find**. Drawer fields use “More info” chips that scroll to the panel.
 - Warnings include a **“Fix this”** deep link that focuses the exact card/field.
 - Optional bottom bar: **Total Income / PITIA / FE / BE** with PASS/CHECK at a glance.
 
@@ -123,7 +127,7 @@ When a new request arrives, the agent must **always**:
 1) **Clarify only critical ambiguity**; otherwise proceed with reasonable defaults.
 2) **Plan** briefly in the PR description: tasks → code → tests → docs → version.
 3) **Implement** the smallest viable change; keep modules cohesive.
-4) **Sync explanations**: update `docs/field_hints.yml` for every new/changed field.
+4) **Sync explanations**: update `docs/field_hints.yml` for every new/changed field and `docs/rulebook.yml` for new/changed warnings.
 5) **Test**: add/adjust unit & integration; update/add a golden scenario only when intended output changes are justified.
 6) **Changelog**: append under **Unreleased**.
 7) **Version**: bump `core/version.py` appropriately.
@@ -134,6 +138,7 @@ When a new request arrives, the agent must **always**:
 - [ ] Golden scenarios pass (or updated intentionally)
 - [ ] `docs/CHANGELOG.md` updated (Unreleased)
 - [ ] `docs/field_hints.yml` updated (new/changed fields)
+- [ ] `docs/rulebook.yml` updated (new/changed warnings)
 - [ ] Version bumped in `core/version.py` and visible in top bar
 - [ ] UX screenshots/GIFs attached
 - [ ] CI green; coverage ≥85%
@@ -181,6 +186,7 @@ CI must block merges unless all of the following are true:
 - `core/version.py` — single source of truth for version.
 - `docs/CHANGELOG.md` — Keep a Changelog.
 - `docs/field_hints.yml` — single source for field help.
+- `docs/rulebook.yml` — single source for warning copy.
 - `tests/` — unit, integration, golden.
 
 ### B) SemVer Guidance

--- a/core/guidance.py
+++ b/core/guidance.py
@@ -1,0 +1,68 @@
+"""Load and access guidance YAML files.
+
+This module provides helpers to read guidance content from
+``docs/field_hints.yml`` and ``docs/rulebook.yml``. Loaded data is cached
+in ``st.session_state['guidance']`` with separate versions for each pack.
+
+The helpers are lightweight and intentionally schema-aware so that YAML
+files are the single source of truth for field explanations and rulebook
+copy.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import streamlit as st
+import yaml
+
+DOCS_DIR = Path(__file__).resolve().parents[1] / "docs"
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def load_field_hints(path: Path | None = None) -> Dict[str, Any]:
+    """Load field hints from YAML and cache them in session state."""
+    path = path or DOCS_DIR / "field_hints.yml"
+    data = _load_yaml(path)
+    version = str(data.get("version", ""))
+    hints = {k: v for k, v in data.items() if k != "version"}
+    st.session_state.setdefault("guidance", {})
+    st.session_state["guidance"]["hints"] = hints
+    st.session_state["guidance"].setdefault("versions", {})["hints"] = version
+    return hints
+
+
+def load_rulebook(path: Path | None = None) -> Dict[str, Any]:
+    """Load rulebook entries from YAML and cache them in session state."""
+    path = path or DOCS_DIR / "rulebook.yml"
+    data = _load_yaml(path)
+    version = str(data.get("version", ""))
+    rules = {k: v for k, v in data.items() if k != "version"}
+    st.session_state.setdefault("guidance", {})
+    st.session_state["guidance"]["rules"] = rules
+    st.session_state["guidance"].setdefault("versions", {})["rules"] = version
+    return rules
+
+
+def get_type_hint(type_id: str) -> Dict[str, Any]:
+    """Return the hint block for a given income/debt type."""
+    return st.session_state.get("guidance", {}).get("hints", {}).get(type_id, {})
+
+
+def get_field_hint(type_id: str, field: str) -> Dict[str, Any]:
+    """Return the hint for a specific field within a type."""
+    return get_type_hint(type_id).get(field, {})
+
+
+def get_rule_text(code: str, program: str | None = None) -> Dict[str, Any]:
+    """Return rulebook text for a finding code, optionally filtered by program."""
+    rule = st.session_state.get("guidance", {}).get("rules", {}).get(code, {})
+    applies = rule.get("applies_to")
+    if applies and program and program not in applies and "global" not in applies:
+        return {}
+    return rule
+

--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Income and debt cards now display borrower, type, employer/title, and monthly totals.
 - Income card creation now allows selecting the income type instead of defaulting to W-2 only.
 - Users can duplicate and remove income and debt cards.
+- YAML-driven guidance spec with loaders, rulebook, and panel scaffolding.
 
 ### Fixed
 - Install pytest in CI workflow to enable test execution.

--- a/docs/field_hints.yml
+++ b/docs/field_hints.yml
@@ -1,26 +1,114 @@
-# field_hints.yml
-# Single source for field help text. Populate as fields are added.
-example_field:
-  label: "Example Field"
-  where: "Example document"
-  definition: "Short description of the field."
+version: "1.0"
 
-borrower_first_name:
-  label: "First name"
-  where: "Borrower application"
-  definition: "Borrower's given name."
+w2:
+  _overview:
+    label: "W-2 Income"
+    what_it_is: "Income from an employer reported on IRS Form W-2."
+    why_it_matters: "Used to qualify borrowers with stable wage income."
+    where_to_find:
+      - "Form W-2"
+      - "Recent paystub"
+  annual_salary:
+    label: "Annual Salary"
+    what_it_is: "Base yearly wage before bonuses or overtime."
+    why_it_matters: "Forms the core qualifying income for most borrowers."
+    where_to_find:
+      - "Paystub YTD Base"
+    docs_required:
+      - "YTD paystub"
+      - "Most recent W-2"
+    program_notes:
+      conventional: "Bonus or overtime requires two-year history."
+      fha: "Include overtime if consistent for 2 years."
 
-borrower_last_name:
-  label: "Last name"
-  where: "Borrower application"
-  definition: "Borrower's family name."
+schc:
+  _overview:
+    label: "Schedule C Income"
+    what_it_is: "Net profit from a sole proprietorship (Form 1040 Schedule C)."
+    why_it_matters: "Business earnings must be stable or increasing."
+    where_to_find:
+      - "Schedule C L31"
+  net_profit:
+    label: "Net Profit"
+    what_it_is: "Profit after expenses from line 31."
+    why_it_matters: "Averaged over two years for qualifying income."
+    where_to_find:
+      - "Schedule C L31"
+    program_notes:
+      va: "Declining income requires significant justification."
 
-borrower_phone:
-  label: "Phone number"
-  where: "Contact information"
-  definition: "Primary phone to reach the borrower."
+k1:
+  _overview:
+    label: "K-1 Income"
+    what_it_is: "Pass-through income from partnerships or S-corps."
+    why_it_matters: "Ownership percentage affects usable income."
+    where_to_find:
+      - "Schedule K-1"
+  ordinary_business_income:
+    label: "Ordinary Business Income"
+    what_it_is: "Line 1 from K-1."
+    why_it_matters: "Core earnings allocated to the partner."
+    where_to_find:
+      - "K-1 Line 1"
+    program_notes:
+      jumbo: "Verify distributions or business liquidity."
 
-borrower_credit_score:
-  label: "Estimated credit score"
-  where: "Credit report"
-  definition: "Approximate FICO or similar score."
+c1120:
+  _overview:
+    label: "1120S/1120 Income"
+    what_it_is: "Corporate earnings from S-Corp or C-Corp returns."
+    why_it_matters: "Requires verified ownership and access to funds."
+    where_to_find:
+      - "Form 1120S/1120"
+  line30:
+    label: "Line 30 Net Income"
+    what_it_is: "Corporate net income after taxes."
+    why_it_matters: "Subject to ownership percentage."
+    where_to_find:
+      - "1120 Line 30"
+    program_notes:
+      conventional: "Only count with 100% ownership."
+
+rental:
+  _overview:
+    label: "Rental Income"
+    what_it_is: "Income from investment or subject properties."
+    why_it_matters: "Offsets housing expense or adds income."
+    where_to_find:
+      - "Schedule E"
+      - "Lease agreement"
+  gross_rents_annual:
+    label: "Gross Annual Rents"
+    what_it_is: "Total rents received before expenses."
+    why_it_matters: "Used for 75% gross method."
+    where_to_find:
+      - "Schedule E"
+
+other_income:
+  _overview:
+    label: "Other Income"
+    what_it_is: "Alimony, child support, or other qualifying income."
+    why_it_matters: "Must continue for at least three years."
+    where_to_find:
+      - "Court order"
+  monthly_amount:
+    label: "Monthly Amount"
+    what_it_is: "Recurring payment received each month."
+    why_it_matters: "Added directly to qualifying income."
+    where_to_find:
+      - "Bank statements"
+
+property:
+  _overview:
+    label: "Subject Property"
+    what_it_is: "Details about the property being financed."
+    why_it_matters: "Determines loan amount and housing expenses."
+    where_to_find:
+      - "Purchase contract"
+  purchase_price:
+    label: "Purchase Price"
+    what_it_is: "Agreed price of the property."
+    why_it_matters: "Basis for loan amount and LTV."
+    where_to_find:
+      - "Contract page 1"
+

--- a/docs/rulebook.yml
+++ b/docs/rulebook.yml
@@ -1,0 +1,32 @@
+version: "1.0"
+
+NO_INCOME:
+  title: "No income entered"
+  message: "At least one source of income is required to qualify."
+  severity: "critical"
+  fix_hint: "Add an income source to continue."
+  applies_to:
+    - global
+  doc_refs:
+    - "Loan application"
+
+W2_VAR_LT_12:
+  title: "Variable income < 12 months"
+  message: "Bonus or overtime income with less than 12 months history cannot be used."
+  severity: "warn"
+  fix_hint: "Provide 12 months history or exclude variable income."
+  applies_to:
+    - w2
+  doc_refs:
+    - "Paystub"
+    - "VOE"
+
+SCHC_DECLINE:
+  title: "Schedule C declining"
+  message: "Net profit declined year over year."
+  severity: "info"
+  fix_hint: "Document reason for decline or use lower income."
+  applies_to:
+    - schc
+  doc_refs:
+    - "Schedule C"

--- a/tests/integration/test_guidance_panel.py
+++ b/tests/integration/test_guidance_panel.py
@@ -1,0 +1,32 @@
+import streamlit as st
+import streamlit as st
+from core.guidance import load_field_hints
+from ui.guidance_panel import render_guidance_panel
+
+
+def _fake_tabs(options):
+    class Dummy:
+        def __enter__(self):
+            return None
+        def __exit__(self, exc_type, exc, tb):
+            return False
+    return [Dummy() for _ in options]
+
+
+def test_panel_switch(monkeypatch):
+    load_field_hints()
+    monkeypatch.setattr(st, "tabs", lambda opts: _fake_tabs(opts))
+    outputs = []
+    monkeypatch.setattr(st, "markdown", lambda msg: outputs.append(msg))
+    monkeypatch.setattr(st, "write", lambda msg: outputs.append(msg))
+    monkeypatch.setattr(st, "caption", lambda msg: outputs.append(msg))
+
+    st.session_state["active_program"] = "conventional"
+    st.session_state["active_context"] = {"type": "w2", "field": None}
+    render_guidance_panel()
+    assert any("W-2 Income" in o for o in outputs)
+
+    outputs.clear()
+    st.session_state["active_context"] = {"type": "w2", "field": "annual_salary"}
+    render_guidance_panel()
+    assert any("Annual Salary" in o for o in outputs)

--- a/tests/unit/test_guidance_loader.py
+++ b/tests/unit/test_guidance_loader.py
@@ -1,0 +1,12 @@
+from core.guidance import load_field_hints, load_rulebook, get_field_hint
+
+
+def test_load_field_hints():
+    hints = load_field_hints()
+    assert "w2" in hints
+    assert get_field_hint("w2", "annual_salary")
+
+
+def test_load_rulebook():
+    rules = load_rulebook()
+    assert "NO_INCOME" in rules

--- a/ui/disclosures.py
+++ b/ui/disclosures.py
@@ -1,34 +1,17 @@
-"""Disclosures component reused across layout and drawer."""
+"""Disclosures component used within the drawer."""
 import streamlit as st
-import yaml
-from pathlib import Path
 from core.presets import DISCLAIMER
 
-_HINTS_CACHE = None
-
-def _load_hints():
-    global _HINTS_CACHE
-    if _HINTS_CACHE is None:
-        with open(Path("docs") / "field_hints.yml", "r", encoding="utf-8") as f:
-            _HINTS_CACHE = yaml.safe_load(f) or {}
-    return _HINTS_CACHE
 
 def render_disclosures(warnings):
-    hints = _load_hints()
-    disc_tab, guides_tab, warn_tab, where_tab = st.tabs([
-        "Disclosures",
-        "Guides",
-        "Warnings",
-        "Where to find",
-    ])
+    """Render only the disclosures and warnings tabs."""
+    disc_tab, guides_tab, warn_tab, where_tab = st.tabs(
+        ["Disclosures", "Guides", "Warnings", "Where to find"]
+    )
     with disc_tab:
         st.caption(DISCLAIMER)
     with guides_tab:
-        if not hints:
-            st.info("No guides available.")
-        else:
-            for key, meta in hints.items():
-                st.write(f"**{meta.get('label', key)}**: {meta.get('definition', '')}")
+        st.info("No guides available.")
     with warn_tab:
         if not warnings:
             st.info("No warnings currently.")
@@ -36,8 +19,4 @@ def render_disclosures(warnings):
             for w in warnings:
                 st.warning(w)
     with where_tab:
-        if not hints:
-            st.info("No field sources available.")
-        else:
-            for key, meta in hints.items():
-                st.write(f"**{meta.get('label', key)}**: {meta.get('where', '')}")
+        st.info("No field sources available.")

--- a/ui/guidance_panel.py
+++ b/ui/guidance_panel.py
@@ -1,0 +1,37 @@
+"""Simple contextual guidance panel.
+
+This component renders markdown pulled from the guidance packs. It is a
+lightweight placeholder intended to validate the data-driven approach.
+"""
+import streamlit as st
+
+from core import guidance
+
+
+def render_guidance_panel():
+    """Render a minimal guidance panel below the top bar."""
+    if "guidance" not in st.session_state:
+        return
+    ctx = st.session_state.get("active_context", {"type": None, "field": None})
+    program = st.session_state.get("active_program", "conventional")
+
+    tabs = st.tabs(["Disclosures", "Guides", "Warnings", "Where to find"])
+
+    with tabs[1]:  # Guides
+        if ctx.get("field"):
+            hint = guidance.get_field_hint(ctx["type"], ctx["field"])
+            if hint:
+                st.markdown(f"**{hint.get('label', '')}**")
+                st.write(hint.get("what_it_is", ""))
+                note = hint.get("program_notes", {}).get(program)
+                if note:
+                    st.caption(note)
+            else:
+                st.write("No guidance available.")
+        elif ctx.get("type"):
+            overview = guidance.get_type_hint(ctx["type"]).get("_overview", {})
+            st.markdown(f"**{overview.get('label', '')}**")
+            st.write(overview.get("what_it_is", ""))
+        else:
+            st.caption("Select a card or field to see guidance.")
+


### PR DESCRIPTION
## Summary
- centralize program-specific guidance in YAML packs for fields and rules
- provide Python helpers and a simple sticky guidance panel
- document and version the new guidance system
- expand agent playbook with guidance panel and rulebook requirements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9344b39a083319eeff4407dcfb29c