### PR TITLE
fix: ensure ui package is importable

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,3 +31,4 @@ All notable changes to this project will be documented in this file.
 - Sidebar remains visible for data entry with disclosures and guides.
 - Replaced bottom summary drawer with top summary band.
 - Dashboard DTI metrics show "—" when income is missing instead of extreme percentages.
+- Add missing `__init__.py` for `ui` package to resolve `KeyError` on import.

--- a/tests/unit/test_ui_import.py
+++ b/tests/unit/test_ui_import.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_ui_utils_importable():
+    module = importlib.import_module("ui.utils")
+    assert hasattr(module, "borrower_name")

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,3 @@
+"""UI package initialization."""
+
+__all__ = []


### PR DESCRIPTION
## Summary
- add missing `__init__.py` so `ui` package loads reliably
- document fix in changelog and bump version to 0.15.1
- cover `ui.utils` import with a lightweight unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a93635d4a48331a3f46a9cf81c7baf