### PR TITLE
feat: enable borrower removal and icon card actions

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 - Income card creation now allows selecting the income type instead of defaulting to W-2 only.
 - Users can duplicate and remove income and debt cards.
 - YAML-driven guidance spec with loaders, rulebook, and panel scaffolding.
+- Borrowers can be removed from the sidebar, clearing their related income and debt cards.
+
+### Changed
+- Income and debt cards open the editor when clicked; duplicate and remove actions use icon buttons.
 
 ### Fixed
 - Install pytest in CI workflow to enable test execution.

--- a/tests/integration/test_borrower_sidebar.py
+++ b/tests/integration/test_borrower_sidebar.py
@@ -24,3 +24,34 @@ def test_render_borrowers_editor(monkeypatch):
     render_borrowers_editor(scn)
     assert "First name" in calls
     assert "Estimated credit score" in calls
+
+
+def test_remove_borrower(monkeypatch):
+    st.session_state.clear()
+    scn = default_scenario()
+    calls = []
+
+    def fake_text_input(label, value="", key=None):
+        calls.append(label)
+        return value
+
+    def fake_number_input(label, value=0, min_value=None, max_value=None, step=None, key=None):
+        calls.append(label)
+        return value
+
+    @contextmanager
+    def fake_expander(label, expanded=False):
+        yield
+
+    def fake_button(label, key=None, **kwargs):
+        return key == "br_rm_1"
+
+    monkeypatch.setattr(st, "text_input", fake_text_input)
+    monkeypatch.setattr(st, "number_input", fake_number_input)
+    monkeypatch.setattr(st, "expander", fake_expander)
+    monkeypatch.setattr(st, "button", fake_button)
+    monkeypatch.setattr(st, "subheader", lambda *args, **kwargs: None)
+
+    render_borrowers_editor(scn)
+    assert 1 not in scn["borrowers"]
+    assert 2 in scn["borrowers"]

--- a/ui/cards_debts.py
+++ b/ui/cards_debts.py
@@ -55,16 +55,18 @@ def render_debt_board(scn):
         name = borrower_name(scn, int(card.get("borrower_id", 1)))
         monthly = debt_monthly(card, policy)
         with st.container(border=True):
-            st.markdown(f"**Borrower:** {name}")
-            st.markdown(f"**Type:** {card.get('type', '')}")
-            st.markdown(f"**Title:** {card.get('name', '')}")
-            st.markdown(f"**Monthly:** ${monthly:,.2f}")
-            c1, c2, c3 = st.columns(3)
-            if c1.button("Edit", key=f"deb_edit_{card['id']}"):
+            summary = (
+                f"Borrower: {name}\n"
+                f"Type: {card.get('type', '')}\n"
+                f"Title: {card.get('name', '')}\n"
+                f"Monthly: ${monthly:,.2f}"
+            )
+            if st.button(summary, key=f"deb_sel_{card['id']}", use_container_width=True):
                 select_debt_card(card["id"])
-            if c2.button("Duplicate", key=f"deb_dup_{card['id']}"):
+            c1, c2 = st.columns(2)
+            if c1.button("📄", key=f"deb_dup_{card['id']}", help="Duplicate"):
                 duplicate_debt_card(scn, card)
                 st.rerun()
-            if c3.button("Remove", key=f"deb_rm_{card['id']}"):
+            if c2.button("🗑️", key=f"deb_rm_{card['id']}", help="Remove"):
                 remove_debt_card(scn, card["id"])
                 st.rerun()

--- a/ui/cards_income.py
+++ b/ui/cards_income.py
@@ -79,16 +79,18 @@ def render_income_board(scn):
         )
         monthly = income_monthly(card)
         with st.container(border=True):
-            st.markdown(f"**Borrower:** {name}")
-            st.markdown(f"**Type:** {card.get('type', '')}")
-            st.markdown(f"**Employer:** {employer}")
-            st.markdown(f"**Monthly:** ${monthly:,.2f}")
-            c1, c2, c3 = st.columns(3)
-            if c1.button("Edit", key=f"inc_edit_{card['id']}"):
+            summary = (
+                f"Borrower: {name}\n"
+                f"Type: {card.get('type', '')}\n"
+                f"Employer: {employer}\n"
+                f"Monthly: ${monthly:,.2f}"
+            )
+            if st.button(summary, key=f"inc_sel_{card['id']}", use_container_width=True):
                 select_income_card(card["id"])
-            if c2.button("Duplicate", key=f"inc_dup_{card['id']}"):
+            c1, c2 = st.columns(2)
+            if c1.button("📄", key=f"inc_dup_{card['id']}", help="Duplicate"):
                 duplicate_income_card(scn, card)
                 st.rerun()
-            if c3.button("Remove", key=f"inc_rm_{card['id']}"):
+            if c2.button("🗑️", key=f"inc_rm_{card['id']}", help="Remove"):
                 remove_income_card(scn, card["id"])
                 st.rerun()

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -28,6 +28,18 @@ def render_borrowers_editor(scn):
     for bid in sorted(scn.get("borrowers", {})):
         br = scn["borrowers"][bid]
         with st.expander(f"Borrower {bid}", expanded=True):
+            if st.button("Remove borrower", key=f"br_rm_{bid}"):
+                scn["borrowers"].pop(bid, None)
+                scn["income_cards"] = [
+                    c for c in scn.get("income_cards", []) if c.get("payload", {}).get("borrower_id") != bid
+                ]
+                scn["debt_cards"] = [
+                    c for c in scn.get("debt_cards", []) if c.get("borrower_id") != bid
+                ]
+                if st.session_state.get("selected_borrower") == bid:
+                    remaining = sorted(scn.get("borrowers", {}))
+                    st.session_state["selected_borrower"] = remaining[0] if remaining else None
+                st.rerun()
             br["first_name"] = st.text_input("First name", value=br.get("first_name", ""), key=f"br_fn_{bid}")
             br["last_name"] = st.text_input("Last name", value=br.get("last_name", ""), key=f"br_ln_{bid}")
             br["phone"] = st.text_input("Phone number", value=br.get("phone", ""), key=f"br_ph_{bid}")


### PR DESCRIPTION
## Summary
- allow borrowers to be removed from sidebar and clear related income and debt cards
- make income and debt cards clickable for editing and swap duplicate/remove buttons with icons
- document feature and bump version

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9392c7eb08331a88ab0645bc0a30b