### PR TITLE
fix: flatten income and debt cards

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.15.2"
+__version__ = "0.15.3"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Income and debt cards open the editor when clicked; duplicate and remove actions use icon buttons.
+- Income and debt cards now show a single bordered box with inline duplicate and remove buttons.
 
 ### Fixed
 - Install pytest in CI workflow to enable test execution.

--- a/ui/cards_debts.py
+++ b/ui/cards_debts.py
@@ -3,7 +3,7 @@ import streamlit as st
 import uuid
 import copy
 from core.calculators import student_loan_payment
-from ui.utils import borrower_name
+from ui.utils import borrower_name, card_select_button
 
 
 def add_debt_card(scn, typ="installment"):
@@ -61,12 +61,15 @@ def render_debt_board(scn):
                 f"Title: {card.get('name', '')}\n"
                 f"Monthly: ${monthly:,.2f}"
             )
-            if st.button(summary, key=f"deb_sel_{card['id']}", use_container_width=True):
-                select_debt_card(card["id"])
-            c1, c2 = st.columns(2)
-            if c1.button("📄", key=f"deb_dup_{card['id']}", help="Duplicate"):
-                duplicate_debt_card(scn, card)
-                st.rerun()
-            if c2.button("🗑️", key=f"deb_rm_{card['id']}", help="Remove"):
-                remove_debt_card(scn, card["id"])
-                st.rerun()
+            c1, c2, c3 = st.columns([0.8, 0.1, 0.1])
+            with c1:
+                if card_select_button(summary, key=f"deb_sel_{card['id']}"):
+                    select_debt_card(card["id"])
+            with c2:
+                if st.button("📄", key=f"deb_dup_{card['id']}", help="Duplicate"):
+                    duplicate_debt_card(scn, card)
+                    st.rerun()
+            with c3:
+                if st.button("🗑️", key=f"deb_rm_{card['id']}", help="Remove"):
+                    remove_debt_card(scn, card["id"])
+                    st.rerun()

--- a/ui/cards_income.py
+++ b/ui/cards_income.py
@@ -11,7 +11,7 @@ from core.calculators import (
     rentals_75pct_gross_monthly,
     other_income_rows_to_monthly,
 )
-from ui.utils import borrower_name
+from ui.utils import borrower_name, card_select_button
 
 
 def add_income_card(scn, typ="W-2"):
@@ -85,12 +85,15 @@ def render_income_board(scn):
                 f"Employer: {employer}\n"
                 f"Monthly: ${monthly:,.2f}"
             )
-            if st.button(summary, key=f"inc_sel_{card['id']}", use_container_width=True):
-                select_income_card(card["id"])
-            c1, c2 = st.columns(2)
-            if c1.button("📄", key=f"inc_dup_{card['id']}", help="Duplicate"):
-                duplicate_income_card(scn, card)
-                st.rerun()
-            if c2.button("🗑️", key=f"inc_rm_{card['id']}", help="Remove"):
-                remove_income_card(scn, card["id"])
-                st.rerun()
+            c1, c2, c3 = st.columns([0.8, 0.1, 0.1])
+            with c1:
+                if card_select_button(summary, key=f"inc_sel_{card['id']}"):
+                    select_income_card(card["id"])
+            with c2:
+                if st.button("📄", key=f"inc_dup_{card['id']}", help="Duplicate"):
+                    duplicate_income_card(scn, card)
+                    st.rerun()
+            with c3:
+                if st.button("🗑️", key=f"inc_rm_{card['id']}", help="Remove"):
+                    remove_income_card(scn, card["id"])
+                    st.rerun()

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -29,3 +29,13 @@ def borrower_name(scn: dict, borrower_id: int) -> str:
     """Return formatted borrower full name for the given ID."""
     b = scn.get("borrowers", {}).get(borrower_id, {})
     return f"{b.get('first_name', '')} {b.get('last_name', '')}".strip() or "Borrower"
+
+
+def card_select_button(label: str, key: str) -> bool:
+    """Render a borderless button that spans its container width."""
+    clicked = st.button(label, key=key, use_container_width=True)
+    st.markdown(
+        f"<style>button#{key} {{text-align:left; border:none; background:none; padding:0;}}</style>",
+        unsafe_allow_html=True,
+    )
+    return clicked


### PR DESCRIPTION
## Plan
- remove nested button boxes from income and debt cards
- add reusable borderless card button helper
- update changelog and version

## Summary
- render income and debt cards as single bordered boxes with inline duplicate/remove buttons
- add `card_select_button` utility for borderless full-width buttons
- bump version to 0.15.3

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a93b07f3388331a4778b4e8570760b