### PR TITLE
fix: fully collapse sidebar and tighten top spacing

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.15.3"
+__version__ = "0.15.4"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Sidebar editor width now doubles `SIDEBAR_WIDTH` using the updated `section[data-testid='stSidebar']` selector for consistency.
 - Property info panel now renders in a third column to the right of debts.
 - Sidebar toggle now hides the drawer completely.
+- Hidden sidebar now releases full width and removes top white bar for more title space.
 
 - Removed left data-entry column; main grid shows income, debts, and property boxes only.
 - Sidebar remains visible for data entry with disclosures and guides.

--- a/tests/unit/test_sidebar_width.py
+++ b/tests/unit/test_sidebar_width.py
@@ -52,3 +52,4 @@ def test_sidebar_hidden(monkeypatch):
 
     assert 'display:none' in captured['html']
     assert 'collapsedControl' in captured['html']
+    assert 'stAppViewContainer' in captured['html'] and 'margin-left:0' in captured['html']

--- a/tests/unit/test_topbar_padding.py
+++ b/tests/unit/test_topbar_padding.py
@@ -1,0 +1,43 @@
+import streamlit as st
+from ui.topbar import render_topbar
+
+
+def test_topbar_removes_padding(monkeypatch):
+    captured = []
+
+    def fake_markdown(html, unsafe_allow_html=False):
+        captured.append(html)
+
+    class DummyColumn:
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            pass
+        def selectbox(self, *a, **k):
+            options = a[1] if len(a) > 1 else []
+            return options[0] if options else None
+        def number_input(self, *a, **k):
+            return 0.0
+        def button(self, *a, **k):
+            return False
+        def markdown(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(st, 'markdown', fake_markdown)
+    monkeypatch.setattr(st, 'container', lambda: DummyColumn())
+    monkeypatch.setattr(
+        st,
+        'columns',
+        lambda *a, **k: [DummyColumn() for _ in range((a[0] if isinstance(a[0], int) else len(a[0])) if a else 1)],
+    )
+    monkeypatch.setattr(st, 'selectbox', lambda *a, **k: a[1][0] if len(a) > 1 and a[1] else None)
+    monkeypatch.setattr(st, 'button', lambda *a, **k: False)
+    monkeypatch.setattr(st, 'number_input', lambda *a, **k: 0.0)
+
+    st.session_state.clear()
+    st.session_state['scenarios'] = {'Default': {'borrowers': {1: {'first_name': '', 'last_name': ''}}}}
+    st.session_state['scenario_name'] = 'Default'
+
+    render_topbar()
+
+    assert any('div.block-container{padding-top:0' in html for html in captured)

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -251,7 +251,11 @@ def render_drawer(scn, warnings=None):
     if open_state:
         css += f"background:{bg};color:{text};}}</style>"
     else:
-        css += "display:none;}}</style><style>div[data-testid='collapsedControl']{display:none;}</style>"
+        css += (
+            "display:none;}}</style>"
+            "<style>div[data-testid='collapsedControl']{display:none;}</style>"
+            "<style>div[data-testid='stAppViewContainer']{margin-left:0;}</style>"
+        )
     st.markdown(css, unsafe_allow_html=True)
 
     with st.sidebar:

--- a/ui/topbar.py
+++ b/ui/topbar.py
@@ -3,6 +3,7 @@ from core import presets as P
 from core.version import __version__
 
 def render_topbar():
+    st.markdown("<style>div.block-container{padding-top:0;}</style>", unsafe_allow_html=True)
     st.markdown("""<style>.topbar{position:sticky;top:0;z-index:999;background:var(--background-color);padding:6px 6px;border-bottom:1px solid #eee}</style>""", unsafe_allow_html=True)
     with st.container():
         st.markdown("<div class='topbar'>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- ensure collapsed sidebar frees layout width
- remove white bar above top bar for more title space
- cover topbar padding removal with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a93c8384fc83319cff27ef27ef72bd