### PR TITLE
fix: remove nested card shadow

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.15.4"
+__version__ = "0.15.5"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Property info panel now renders in a third column to the right of debts.
 - Sidebar toggle now hides the drawer completely.
 - Hidden sidebar now releases full width and removes top white bar for more title space.
+- Remove inner button shadow to eliminate nested card borders.
 
 - Removed left data-entry column; main grid shows income, debts, and property boxes only.
 - Sidebar remains visible for data entry with disclosures and guides.

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -35,7 +35,7 @@ def card_select_button(label: str, key: str) -> bool:
     """Render a borderless button that spans its container width."""
     clicked = st.button(label, key=key, use_container_width=True)
     st.markdown(
-        f"<style>button#{key} {{text-align:left; border:none; background:none; padding:0;}}</style>",
+        f"<style>button#{key} {{text-align:left; border:none; background:none; padding:0; box-shadow:none;}}</style>",
         unsafe_allow_html=True,
     )
     return clicked


### PR DESCRIPTION
## Summary
- drop residual button shadow so income/debt cards show single border
- bump version to 0.15.5

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a93da3357483318d29c3590a06a6f5