### PR TITLE
fix: adjust sidebar toggle and top bar

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.15.5"
+__version__ = "0.15.6"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Install pytest in CI workflow to enable test execution.
+- Collapsed sidebar no longer leaves unused space and toggle arrow sits at the top-left; sidebar opens when editing cards.
 - Scrollable container layout with bottom bar document checklist.
 - Sidebar and bottom bar toggle arrows with dark gray styling.
 - Sidebar headers now appear inside their bordered boxes for clearer grouping.

--- a/tests/unit/test_sidebar_auto_open.py
+++ b/tests/unit/test_sidebar_auto_open.py
@@ -1,0 +1,16 @@
+import streamlit as st
+from contextlib import nullcontext
+from ui import sidebar_editor
+
+
+def test_sidebar_opens_when_editor_active(monkeypatch):
+    st.session_state.clear()
+    st.session_state["drawer_open"] = False
+    st.session_state["active_editor"] = {"kind": "income", "id": "1"}
+
+    monkeypatch.setattr(st, "sidebar", nullcontext())
+    monkeypatch.setattr(sidebar_editor, "render_context_form", lambda active, scn, warnings: None)
+    monkeypatch.setattr(st, "markdown", lambda *args, **kwargs: None)
+
+    sidebar_editor.render_drawer({})
+    assert st.session_state["drawer_open"] is True

--- a/tests/unit/test_sidebar_width.py
+++ b/tests/unit/test_sidebar_width.py
@@ -23,7 +23,7 @@ def test_sidebar_drawer_width(monkeypatch):
     st.session_state.clear()
     sidebar_editor.render_drawer({})
 
-    width = SIDEBAR_WIDTH * 2
+    width = SIDEBAR_WIDTH
     assert "section[data-testid='stSidebar']" in captured['html']
     assert f"width:{width}px" in captured['html']
     assert f"max-width:{width}px" in captured['html']

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -243,19 +243,23 @@ def render_drawer(scn, warnings=None):
     colors = THEME["colors"]
     bg = colors.get("panel_bg", "#222")
     text = colors.get("panel_text", "#fff")
+
+    # Auto-open drawer when an editor is active
+    if st.session_state.get("active_editor") and not st.session_state.get("drawer_open", True):
+        st.session_state["drawer_open"] = True
+
     open_state = st.session_state.get("drawer_open", True)
-    width = SIDEBAR_WIDTH * 2 if open_state else 0
+    width = SIDEBAR_WIDTH if open_state else 0
     css = (
         f"<style>section[data-testid='stSidebar']{{width:{width}px !important;max-width:{width}px !important;"
     )
     if open_state:
         css += f"background:{bg};color:{text};}}</style>"
     else:
-        css += (
-            "display:none;}}</style>"
-            "<style>div[data-testid='collapsedControl']{display:none;}</style>"
-            "<style>div[data-testid='stAppViewContainer']{margin-left:0;}</style>"
-        )
+        css += "display:none;}}</style>" + "<style>div[data-testid='stAppViewContainer']{margin-left:0;}</style>"
+
+    # Reposition toggle control to top-left for both states
+    css += "<style>div[data-testid='collapsedControl']{position:fixed;top:0;left:0;}</style>"
     st.markdown(css, unsafe_allow_html=True)
 
     with st.sidebar:

--- a/ui/topbar.py
+++ b/ui/topbar.py
@@ -3,7 +3,7 @@ from core import presets as P
 from core.version import __version__
 
 def render_topbar():
-    st.markdown("<style>div.block-container{padding-top:0;}</style>", unsafe_allow_html=True)
+    st.markdown("<style>div.block-container{padding-top:0.5rem;}</style>", unsafe_allow_html=True)
     st.markdown("""<style>.topbar{position:sticky;top:0;z-index:999;background:var(--background-color);padding:6px 6px;border-bottom:1px solid #eee}</style>""", unsafe_allow_html=True)
     with st.container():
         st.markdown("<div class='topbar'>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- eliminate leftover space when sidebar is collapsed and keep toggle at top-left
- auto-open sidebar when editing items and add breathing room above top bar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a93f753298833189c75cb5f26e5aa3