### PR TITLE
feat: make income and debt cards fully clickable

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.15.6"
+__version__ = "0.16.0"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,8 +14,7 @@ All notable changes to this project will be documented in this file.
 - Borrowers can be removed from the sidebar, clearing their related income and debt cards.
 
 ### Changed
-- Income and debt cards open the editor when clicked; duplicate and remove actions use icon buttons.
-- Income and debt cards now show a single bordered box with inline duplicate and remove buttons.
+- Income and debt cards use a single bordered surface that opens the editor on click while Duplicate and Remove buttons sit inline and do not trigger the primary action.
 
 ### Fixed
 - Install pytest in CI workflow to enable test execution.

--- a/ui/cards_debts.py
+++ b/ui/cards_debts.py
@@ -3,7 +3,7 @@ import streamlit as st
 import uuid
 import copy
 from core.calculators import student_loan_payment
-from ui.utils import borrower_name, card_select_button
+from ui.utils import borrower_name
 
 
 def add_debt_card(scn, typ="installment"):
@@ -54,22 +54,40 @@ def render_debt_board(scn):
     for card in scn.get("debt_cards", []):
         name = borrower_name(scn, int(card.get("borrower_id", 1)))
         monthly = debt_monthly(card, policy)
+        card_id = card["id"]
+        open_key = f"deb_open_{card_id}"
+        dup_key = f"deb_dup_{card_id}"
+        rm_key = f"deb_rm_{card_id}"
         with st.container(border=True):
-            summary = (
-                f"Borrower: {name}\n"
-                f"Type: {card.get('type', '')}\n"
-                f"Title: {card.get('name', '')}\n"
-                f"Monthly: ${monthly:,.2f}"
-            )
-            c1, c2, c3 = st.columns([0.8, 0.1, 0.1])
+            c1, c2, c3, c4 = st.columns([0.55, 0.25, 0.1, 0.1])
             with c1:
-                if card_select_button(summary, key=f"deb_sel_{card['id']}"):
-                    select_debt_card(card["id"])
+                st.write(f"{card.get('type', '')}: {card.get('name', '')}")
+                st.caption(name)
             with c2:
-                if st.button("📄", key=f"deb_dup_{card['id']}", help="Duplicate"):
+                st.write(f"${monthly:,.2f}/mo")
+            with c3:
+                if st.button("📄", key=dup_key, help="Duplicate"):
                     duplicate_debt_card(scn, card)
                     st.rerun()
-            with c3:
-                if st.button("🗑️", key=f"deb_rm_{card['id']}", help="Remove"):
-                    remove_debt_card(scn, card["id"])
+            with c4:
+                if st.button("🗑️", key=rm_key, help="Remove"):
+                    remove_debt_card(scn, card_id)
                     st.rerun()
+            if st.button(" ", key=open_key, label_visibility="collapsed"):
+                select_debt_card(card_id)
+            st.markdown(
+                f"""
+                <style>
+                button#{open_key} {{
+                    position: absolute;
+                    top: 0; left: 0; width: 100%; height: 100%;
+                    border: none; background: none; padding: 0;
+                    cursor: pointer; z-index: 0;
+                }}
+                button#{dup_key}, button#{rm_key} {{
+                    position: relative; z-index: 1;
+                }}
+                </style>
+                """,
+                unsafe_allow_html=True,
+            )

--- a/ui/cards_income.py
+++ b/ui/cards_income.py
@@ -11,7 +11,7 @@ from core.calculators import (
     rentals_75pct_gross_monthly,
     other_income_rows_to_monthly,
 )
-from ui.utils import borrower_name, card_select_button
+from ui.utils import borrower_name
 
 
 def add_income_card(scn, typ="W-2"):
@@ -78,22 +78,40 @@ def render_income_board(scn):
             or ""
         )
         monthly = income_monthly(card)
+        card_id = card["id"]
+        open_key = f"inc_open_{card_id}"
+        dup_key = f"inc_dup_{card_id}"
+        rm_key = f"inc_rm_{card_id}"
         with st.container(border=True):
-            summary = (
-                f"Borrower: {name}\n"
-                f"Type: {card.get('type', '')}\n"
-                f"Employer: {employer}\n"
-                f"Monthly: ${monthly:,.2f}"
-            )
-            c1, c2, c3 = st.columns([0.8, 0.1, 0.1])
+            c1, c2, c3, c4 = st.columns([0.55, 0.25, 0.1, 0.1])
             with c1:
-                if card_select_button(summary, key=f"inc_sel_{card['id']}"):
-                    select_income_card(card["id"])
+                st.write(f"{card.get('type', '')}: {employer}")
+                st.caption(name)
             with c2:
-                if st.button("📄", key=f"inc_dup_{card['id']}", help="Duplicate"):
+                st.write(f"${monthly:,.2f}/mo")
+            with c3:
+                if st.button("📄", key=dup_key, help="Duplicate"):
                     duplicate_income_card(scn, card)
                     st.rerun()
-            with c3:
-                if st.button("🗑️", key=f"inc_rm_{card['id']}", help="Remove"):
-                    remove_income_card(scn, card["id"])
+            with c4:
+                if st.button("🗑️", key=rm_key, help="Remove"):
+                    remove_income_card(scn, card_id)
                     st.rerun()
+            if st.button(" ", key=open_key, label_visibility="collapsed"):
+                select_income_card(card_id)
+            st.markdown(
+                f"""
+                <style>
+                button#{open_key} {{
+                    position: absolute;
+                    top: 0; left: 0; width: 100%; height: 100%;
+                    border: none; background: none; padding: 0;
+                    cursor: pointer; z-index: 0;
+                }}
+                button#{dup_key}, button#{rm_key} {{
+                    position: relative; z-index: 1;
+                }}
+                </style>
+                """,
+                unsafe_allow_html=True,
+            )


### PR DESCRIPTION
## Summary
- make income and debt cards one fully-clickable surface
- keep duplicate/remove actions inline without triggering the card
- bump version to 0.16.0

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a940ab97f08331aba049ee9cbbf3b5