### PR TITLE
fix: remove unsupported label_visibility from income card

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,3 +39,4 @@ All notable changes to this project will be documented in this file.
 - Replaced bottom summary drawer with top summary band.
 - Dashboard DTI metrics show "—" when income is missing instead of extreme percentages.
 - Add missing `__init__.py` for `ui` package to resolve `KeyError` on import.
+- Avoid TypeError by removing unsupported `label_visibility` from income card open button.

--- a/tests/unit/test_cards_binding.py
+++ b/tests/unit/test_cards_binding.py
@@ -49,6 +49,19 @@ def test_render_income_board_sets_new(monkeypatch):
     assert st.session_state["active_editor"] == {"kind": "income_new"}
 
 
+def test_render_income_board_no_extra_kwargs(monkeypatch):
+    """Ensure render_income_board uses only supported st.button parameters."""
+    st.session_state.clear()
+    scn = {"income_cards": []}
+
+    def strict_button(label, key=None, help=None, on_click=None, args=None, kwargs=None, type="secondary", disabled=False, use_container_width=False):
+        """A stub mimicking st.button without **kwargs to surface unexpected params."""
+        return False
+
+    monkeypatch.setattr(st, "button", strict_button)
+    render_income_board(scn)
+
+
 def test_duplicate_and_remove_income_cards():
     st.session_state.clear()
     card = {"id": "a", "type": "W-2", "payload": {}}

--- a/ui/cards_income.py
+++ b/ui/cards_income.py
@@ -97,7 +97,10 @@ def render_income_board(scn):
                 if st.button("🗑️", key=rm_key, help="Remove"):
                     remove_income_card(scn, card_id)
                     st.rerun()
-            if st.button(" ", key=open_key, label_visibility="collapsed"):
+            # Use an invisible button overlay to open the editor when the card is clicked.
+            # `st.button` does not support the `label_visibility` parameter, so we avoid
+            # passing it to prevent a TypeError at runtime.
+            if st.button(" ", key=open_key):
                 select_income_card(card_id)
             st.markdown(
                 f"""


### PR DESCRIPTION
## Summary
- remove unsupported `label_visibility` from income card's overlay button to stop TypeError
- add regression test to ensure no unexpected Streamlit button kwargs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a94247805883319340a5d88f4d72df