### PR TITLE
fix: remove unsupported label_visibility from debt card button

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.16.1"
+__version__ = "0.16.2"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,3 +40,4 @@ All notable changes to this project will be documented in this file.
 - Dashboard DTI metrics show "—" when income is missing instead of extreme percentages.
 - Add missing `__init__.py` for `ui` package to resolve `KeyError` on import.
 - Avoid TypeError by removing unsupported `label_visibility` from income card open button.
+- Avoid TypeError by removing unsupported `label_visibility` from debt card open button.

--- a/tests/integration/test_debt_board.py
+++ b/tests/integration/test_debt_board.py
@@ -1,0 +1,52 @@
+import streamlit as st
+from ui.cards_debts import render_debt_board
+
+
+def test_render_debt_board_monkeypatch(monkeypatch):
+    st.session_state.clear()
+    scn = {
+        "debt_cards": [
+            {
+                "id": "abcd1234",
+                "borrower_id": 1,
+                "type": "installment",
+                "name": "Car loan",
+                "monthly_payment": 100.0,
+            }
+        ]
+    }
+
+    calls = []
+
+    def fake_button(label, key=None, **kwargs):
+        calls.append({"label": label, "key": key, "kwargs": kwargs})
+        return False
+
+    class Dummy:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_container(border=True):
+        return Dummy()
+
+    def fake_columns(spec):
+        return Dummy(), Dummy(), Dummy(), Dummy()
+
+    monkeypatch.setattr(st, "button", fake_button)
+    monkeypatch.setattr(st, "container", fake_container)
+    monkeypatch.setattr(st, "columns", fake_columns)
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "write", lambda *a, **k: None)
+    monkeypatch.setattr(st, "caption", lambda *a, **k: None)
+    monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
+    monkeypatch.setattr(st, "rerun", lambda: None)
+
+    render_debt_board(scn)
+
+    assert any(
+        call["key"] and call["key"].startswith("deb_open_") and "label_visibility" not in call["kwargs"]
+        for call in calls
+    )

--- a/ui/cards_debts.py
+++ b/ui/cards_debts.py
@@ -73,7 +73,7 @@ def render_debt_board(scn):
                 if st.button("🗑️", key=rm_key, help="Remove"):
                     remove_debt_card(scn, card_id)
                     st.rerun()
-            if st.button(" ", key=open_key, label_visibility="collapsed"):
+            if st.button(" ", key=open_key):
                 select_debt_card(card_id)
             st.markdown(
                 f"""


### PR DESCRIPTION
## Summary
- drop invalid `label_visibility` on debt card open button to prevent runtime TypeError
- add integration test for debt board button rendering
- bump version to 0.16.2 and update changelog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a94318f38c83318e3a7ff94f56b60e