### PR TITLE
feat: overlay sidebar drawer and summary band fix

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,6 +1,6 @@
 """Project version information."""
 
 
-__version__ = "0.16.2"
+__version__ = "0.17.0"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,9 +12,11 @@ All notable changes to this project will be documented in this file.
 - Users can duplicate and remove income and debt cards.
 - YAML-driven guidance spec with loaders, rulebook, and panel scaffolding.
 - Borrowers can be removed from the sidebar, clearing their related income and debt cards.
+- Smoke test covers drawer toggle, auto-open behaviour, and summary band visibility.
 
 ### Changed
 - Income and debt cards use a single bordered surface that opens the editor on click while Duplicate and Remove buttons sit inline and do not trigger the primary action.
+- Sidebar drawer now overlays content at ~640px width with top-left chevron and a top-bar "Show sidebar" button; editing any card auto-opens the drawer.
 
 ### Fixed
 - Install pytest in CI workflow to enable test execution.
@@ -41,3 +43,4 @@ All notable changes to this project will be documented in this file.
 - Add missing `__init__.py` for `ui` package to resolve `KeyError` on import.
 - Avoid TypeError by removing unsupported `label_visibility` from income card open button.
 - Avoid TypeError by removing unsupported `label_visibility` from debt card open button.
+- Summary band offset ensures it remains fully visible beneath the top bar.

--- a/tests/integration/test_sidebar_summary_smoke.py
+++ b/tests/integration/test_sidebar_summary_smoke.py
@@ -1,0 +1,54 @@
+import streamlit as st
+
+from ui import layout
+import ui.sidebar_editor as sidebar_editor
+from ui.sidebar_editor import render_drawer
+from ui.summary_band import render_summary_band
+from ui.utils import show_sidebar, hide_sidebar
+from ui.cards_income import select_income_card
+
+
+def test_sidebar_summary_smoke(monkeypatch):
+    st.session_state.clear()
+    scn = {"income_cards": [{"id": "abc", "type": "W-2", "payload": {}}], "debt_cards": [], "housing": {}}
+
+    # Toggle drawer open/close
+    show_sidebar()
+    assert st.session_state["drawer_open"] is True
+    hide_sidebar()
+    assert st.session_state["drawer_open"] is False
+
+    # Layout still renders 3 columns when drawer is hidden
+    col_meta = {}
+
+    def fake_columns(spec):
+        n = len(spec) if isinstance(spec, (list, tuple)) else spec
+        if "n" not in col_meta:
+            col_meta["n"] = n
+        class DummyCol:
+            def __enter__(self):
+                return self
+            def __exit__(self, exc_type, exc, tb):
+                return False
+        return tuple(DummyCol() for _ in range(n))
+
+    monkeypatch.setattr(st, "columns", fake_columns)
+    layout.render_layout(scn)
+    assert col_meta["n"] == 3
+
+    # Auto-open drawer when selecting a card while hidden
+    st.session_state["active_editor"] = None
+    hide_sidebar()
+    select_income_card("abc")
+    monkeypatch.setattr(sidebar_editor, "render_context_form", lambda *a, **k: None)
+    render_drawer(scn)
+    assert st.session_state["drawer_open"] is True
+
+    # Summary band renders sticky below top bar
+    captured = {}
+    def fake_markdown(msg, *a, **k):
+        captured.setdefault("calls", []).append(msg)
+    monkeypatch.setattr(st, "markdown", fake_markdown)
+    label = render_summary_band({"TotalIncome":0,"PITIA":0,"FE":0,"BE":0,"FE_target":1,"BE_target":1,"LTV":0})
+    assert any("#summary_toggle" in c and "position:sticky" in c for c in captured["calls"])
+    assert label.startswith("Total Income")

--- a/tests/unit/test_sidebar_width.py
+++ b/tests/unit/test_sidebar_width.py
@@ -4,10 +4,10 @@ from ui.layout_helpers import SIDEBAR_WIDTH
 
 
 def test_sidebar_drawer_width(monkeypatch):
-    captured = {}
+    captured = []
 
     def fake_markdown(html, unsafe_allow_html=False):
-        captured['html'] = html
+        captured.append(html)
 
     monkeypatch.setattr(st, 'markdown', fake_markdown)
 
@@ -23,17 +23,17 @@ def test_sidebar_drawer_width(monkeypatch):
     st.session_state.clear()
     sidebar_editor.render_drawer({})
 
-    width = SIDEBAR_WIDTH
-    assert "section[data-testid='stSidebar']" in captured['html']
-    assert f"width:{width}px" in captured['html']
-    assert f"max-width:{width}px" in captured['html']
+    combined = "".join(captured)
+    width_css = f"min(90vw, {SIDEBAR_WIDTH}px)"
+    assert "section[data-testid='stSidebar']" in combined
+    assert width_css in combined
 
 
 def test_sidebar_hidden(monkeypatch):
-    captured = {}
+    captured = []
 
     def fake_markdown(html, unsafe_allow_html=False):
-        captured['html'] = html
+        captured.append(html)
 
     monkeypatch.setattr(st, 'markdown', fake_markdown)
 
@@ -50,6 +50,7 @@ def test_sidebar_hidden(monkeypatch):
     st.session_state['drawer_open'] = False
     sidebar_editor.render_drawer({})
 
-    assert 'display:none' in captured['html']
-    assert 'collapsedControl' in captured['html']
-    assert 'stAppViewContainer' in captured['html'] and 'margin-left:0' in captured['html']
+    combined = "".join(captured)
+    assert 'display:none' in combined
+    assert 'collapsedControl' in combined
+    assert 'stAppViewContainer' in combined and 'margin-left:0' in combined

--- a/ui/layout_helpers.py
+++ b/ui/layout_helpers.py
@@ -1,7 +1,9 @@
 """Helper functions for layout styling."""
 from __future__ import annotations
 
-SIDEBAR_WIDTH = 260
+# Default width for the sidebar editor drawer. The drawer will clamp to this
+# value on wide screens and use 90% of the viewport width on narrow devices.
+SIDEBAR_WIDTH = 640
 
 
 def build_sidebar_css(panel_bg: str, panel_text: str, visible: bool, width: int = SIDEBAR_WIDTH) -> str:

--- a/ui/sidebar_editor.py
+++ b/ui/sidebar_editor.py
@@ -237,30 +237,66 @@ def render_context_form(active, scn, warnings):
     render_disclosures(warnings)
 
 def render_drawer(scn, warnings=None):
-    """Render the editor sidebar permanently on screen."""
+    """Render the editor sidebar as an overlay drawer."""
 
     warnings = warnings or []
     colors = THEME["colors"]
     bg = colors.get("panel_bg", "#222")
     text = colors.get("panel_text", "#fff")
 
-    # Auto-open drawer when an editor is active
+    # Auto-open drawer when an editor is activated while hidden
     if st.session_state.get("active_editor") and not st.session_state.get("drawer_open", True):
         st.session_state["drawer_open"] = True
 
     open_state = st.session_state.get("drawer_open", True)
-    width = SIDEBAR_WIDTH if open_state else 0
-    css = (
-        f"<style>section[data-testid='stSidebar']{{width:{width}px !important;max-width:{width}px !important;"
-    )
-    if open_state:
-        css += f"background:{bg};color:{text};}}</style>"
-    else:
-        css += "display:none;}}</style>" + "<style>div[data-testid='stAppViewContainer']{margin-left:0;}</style>"
+    width_css = f"min(90vw, {SIDEBAR_WIDTH}px)"
 
-    # Reposition toggle control to top-left for both states
-    css += "<style>div[data-testid='collapsedControl']{position:fixed;top:0;left:0;}</style>"
-    st.markdown(css, unsafe_allow_html=True)
+    base_css = f"""
+    <style>
+    div[data-testid='collapsedControl']{{display:none;}}
+    section[data-testid='stSidebar']{{position:fixed;top:0;bottom:0;left:0;z-index:1001;}}
+    div[data-testid='stAppViewContainer']{{margin-left:0;}}
+    </style>
+    """
+    st.markdown(base_css, unsafe_allow_html=True)
+
+    if open_state:
+        st.markdown(
+            f"""
+            <style>
+            section[data-testid='stSidebar']{{width:{width_css};max-width:{width_css};background:{bg};color:{text};box-shadow:2px 0 8px rgba(0,0,0,0.2);padding-top:32px;}}
+            #drawer_overlay_btn{{position:fixed;top:0;left:0;width:100vw;height:100vh;background:rgba(0,0,0,0.4);border:none;z-index:1000;}}
+            button#drawer_close{{position:absolute;top:8px;left:8px;}}
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
+        if st.button("", key="drawer_overlay_btn"):
+            st.session_state["drawer_open"] = False
+            st.rerun()
+    else:
+        st.markdown(
+            "<style>section[data-testid='stSidebar']{display:none;}</style>",
+            unsafe_allow_html=True,
+        )
+
+    # Close on Esc by triggering the overlay button
+    st.markdown(
+        """
+        <script>
+        document.addEventListener('keydown', function(e){
+            if(e.key === 'Escape'){
+                var btn = parent.document.getElementById('drawer_overlay_btn');
+                if(btn){btn.click();}
+            }
+        });
+        </script>
+        """,
+        unsafe_allow_html=True,
+    )
 
     with st.sidebar:
+        if st.button("⮜⮜", key="drawer_close", help="Close sidebar"):
+            st.session_state["drawer_open"] = False
+            st.rerun()
         render_context_form(st.session_state.get("active_editor"), scn, warnings)

--- a/ui/summary_band.py
+++ b/ui/summary_band.py
@@ -58,7 +58,7 @@ def render_summary_band(summary: dict) -> str:
     <style>
     #summary_toggle{{width:100%;text-align:left;padding:{spacing['space_sm']}px;background:{colors['surface']};
     border:1px solid {colors['border']};border-radius:{radii['radius_md']}px;box-shadow:{THEME['shadows']['card']};
-    position:sticky;top:48px;z-index:998;}}
+    position:sticky;top:60px;z-index:998;white-space:normal;}}
     </style>
     """
     st.markdown(style, unsafe_allow_html=True)

--- a/ui/topbar.py
+++ b/ui/topbar.py
@@ -9,6 +9,10 @@ def render_topbar():
         st.markdown("<div class='topbar'>", unsafe_allow_html=True)
         c1,c2,c3,c4 = st.columns([2,3,5,3])
         with c1:
+            if not st.session_state.get("drawer_open", True):
+                if st.button("Show sidebar", key="tb_show_sidebar"):
+                    st.session_state["drawer_open"] = True
+                    st.rerun()
             st.markdown(f"### AMALO — v{__version__}")
         with c2:
             scn = st.session_state["scenarios"][st.session_state["scenario_name"]]


### PR DESCRIPTION
## Summary
- make sidebar drawer a 640px overlay with top-left chevron and top-bar show button
- auto-open drawer on card edits and keep summary band fully visible
- add integration smoke test for drawer toggle and summary band

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9456c407c83319c7e7c6cfb48d816